### PR TITLE
Fix brush tool on rasters with different sizes

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -304,7 +304,7 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
   if (!viewer) return;
 
   TRasterImageP ri = (TRasterImageP)getImage(true);
-  if (!ri) ri = (TRasterImageP)touchImage();
+  if (!ri) ri      = (TRasterImageP)touchImage();
 
   if (!ri) return;
 
@@ -580,12 +580,12 @@ void FullColorBrushTool::setWorkAndBackupImages() {
   TRasterP ras   = ri->getRaster();
   TDimension dim = ras->getSize();
 
-  if (!m_workRaster || m_workRaster->getLx() > dim.lx ||
-      m_workRaster->getLy() > dim.ly)
+  if (!m_workRaster || m_workRaster->getLx() != dim.lx ||
+      m_workRaster->getLy() != dim.ly)
     m_workRaster = TRaster32P(dim);
 
-  if (!m_backUpRas || m_backUpRas->getLx() > dim.lx ||
-      m_backUpRas->getLy() > dim.ly ||
+  if (!m_backUpRas || m_backUpRas->getLx() != dim.lx ||
+      m_backUpRas->getLy() != dim.ly ||
       m_backUpRas->getPixelSize() != ras->getPixelSize())
     m_backUpRas = ras->create(dim.lx, dim.ly);
 


### PR DESCRIPTION
This fixes the issue where using the brush on raster levels of different sizes didn't use the whole level on the larger image.

Fix for OpenToonz 3283