### PR TITLE
Allow Straight Lines on Shift plus more. . .

### DIFF
--- a/toonz/sources/include/toonz/rasterstrokegenerator.h
+++ b/toonz/sources/include/toonz/rasterstrokegenerator.h
@@ -79,5 +79,6 @@ public:
 
   TRect getLastRect() const;
 
-  TRect generateLastPieceOfStroke(bool isPencil, bool closeStroke = false);
+  TRect generateLastPieceOfStroke(bool isPencil, bool closeStroke = false,
+                                  bool isStraight = false);
 };

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -225,6 +225,11 @@ protected:
 
   bool m_propertyUpdating = false;
 
+  bool m_isStraight = false;
+  bool m_isLockedVH = false;
+  TPointD m_firstPoint;
+  TPointD m_lastPoint;
+
 protected:
   static void drawLine(const TPointD &point, const TPointD &centre,
                        bool horizontal, bool isDecimal);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -226,7 +226,6 @@ protected:
   bool m_propertyUpdating = false;
 
   bool m_isStraight = false;
-  bool m_isLockedVH = false;
   TPointD m_firstPoint;
   TPointD m_lastPoint;
 

--- a/toonz/sources/toonzlib/rasterstrokegenerator.cpp
+++ b/toonz/sources/toonzlib/rasterstrokegenerator.cpp
@@ -105,11 +105,15 @@ void RasterStrokeGenerator::generateStroke(bool isPencil) const {
 //-----------------------------------------------------------
 
 TRect RasterStrokeGenerator::generateLastPieceOfStroke(bool isPencil,
-                                                       bool closeStroke) {
+                                                       bool closeStroke,
+                                                       bool isStraight) {
   std::vector<TThickPoint> points;
   int size = m_points.size();
 
-  if (size == 3) {
+  if (isStraight) {
+    points.push_back(m_points[0]);
+    points.push_back(m_points[2]);
+  } else if (size == 3) {
     points.push_back(m_points[0]);
     points.push_back(m_points[1]);
   } else if (size == 1)
@@ -330,7 +334,7 @@ TRect RasterStrokeGenerator::getLastRect() const {
 
   if (size == 3) {
     points.push_back(m_points[0]);
-    points.push_back(m_points[1]);
+    points.push_back(m_points[2]);
   } else if (size == 1)
     points.push_back(m_points[0]);
   else {

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -517,10 +517,12 @@ FlipConsole::FlipConsole(QVBoxLayout *mainLayout, std::vector<int> gadgetsMask,
                      SLOT(onNextFrame(int)), Qt::BlockingQueuedConnection);
   ret = ret && connect(&m_playbackExecutor, SIGNAL(playbackAborted()), this,
                        SLOT(setFpsFieldColors()));
-  ret = ret && connect(m_fpsField, SIGNAL(controlClickEvent()), this,
-                       SLOT(resetToSceneFps()));
-  ret = ret && connect(m_fpsField, SIGNAL(controlAltClickEvent()), this,
-                       SLOT(setSceneFpsToCurrent()));
+  if (m_fpsField) {
+    ret = ret && connect(m_fpsField, SIGNAL(controlClickEvent()), this,
+                         SLOT(resetToSceneFps()));
+    ret = ret && connect(m_fpsField, SIGNAL(controlAltClickEvent()), this,
+                         SLOT(setSceneFpsToCurrent()));
+  }
 
   assert(ret);
 
@@ -1826,7 +1828,7 @@ QFrame *FlipConsole::createFrameSlider() {
   m_currFrameSlider->setValue(0);
 
   m_timeLabel = new QLabel(QString("00:00:00"), frameSliderFrame);
-  m_timeLabel->setFixedWidth(m_fpsLabel->fontMetrics().width("00:00:00"));
+  m_timeLabel->setFixedWidth(m_timeLabel->fontMetrics().width("00:00:00"));
   m_timeLabel->setAlignment(Qt::AlignHCenter | Qt::AlignVCenter);
   m_timeLabel->setStyleSheet("padding: 0px; margin: 0px;");
 
@@ -1859,6 +1861,8 @@ QFrame *FlipConsole::createFrameSlider() {
           SLOT(OnSetCurrentFrame(int)));
   connect(m_currFrameSlider, SIGNAL(flipSliderReleased()), this,
           SLOT(OnFrameSliderRelease()));
+
+  if (!m_fpsField) m_timeLabel->hide();
 
   return frameSliderFrame;
 }


### PR DESCRIPTION
This allows holding shift on to get straight lines on Toonz Raster levels.  
You can also hold control (command) to snap to vertical, horizontal or diagonal lines.

The same functionality will be coming to Raster and Vector levels.