### PR TITLE
Perspective Assistant for Smart Raster and Raster levels

### DIFF
--- a/toonz/sources/include/toonz/levelproperties.h
+++ b/toonz/sources/include/toonz/levelproperties.h
@@ -55,6 +55,8 @@ public:
       //!  are not).
       m_isStopMotionLevel;
 
+  std::vector<TPointD> m_vanishingPoints;
+
 public:
   LevelOptions();  //!< Constructs with default values.
 
@@ -228,6 +230,14 @@ ie
     m_options.m_isStopMotionLevel = isStopMotion;
   }
   bool isStopMotionLevel() const { return m_options.m_isStopMotionLevel; }
+
+  void setVanishingPoints(std::vector<TPointD> vanishingPoints) {
+    m_options.m_vanishingPoints = vanishingPoints;
+  }
+
+  std::vector<TPointD> getVanishingPoints() {
+    return m_options.m_vanishingPoints;
+  }
 
 private:
   TPointD m_imageDpi;

--- a/toonz/sources/include/toonz/rasterstrokegenerator.h
+++ b/toonz/sources/include/toonz/rasterstrokegenerator.h
@@ -65,7 +65,7 @@ public:
   void add(const TThickPoint &p);
 
   // Disegna il tratto interamente
-  void generateStroke(bool isPencil) const;
+  void generateStroke(bool isPencil, bool isStraight = false) const;
 
   // Ritorna m_points
   std::vector<TThickPoint> getPointsSequence() { return m_points; }

--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -308,9 +308,28 @@ void FullColorBrushTool::leftButtonDown(const TPointD &pos,
 
   if (!ri) return;
 
+  TTool::Application *app = TTool::getApplication();
+  if (!app) return;
+  TXshLevel *level          = app->getCurrentLevel()->getLevel();
+  TXshSimpleLevelP simLevel = level->getSimpleLevel();
+  m_assistantPoints         = simLevel->getProperties()->getVanishingPoints();
+
   if (e.isAltPressed() && e.isCtrlPressed() && !e.isShiftPressed()) {
     m_addingAssistant = true;
-    m_assistantPoints.push_back(pos);
+    bool deletedPoint = false;
+    for (int i = 0; i < m_assistantPoints.size(); i++) {
+      if (areAlmostEqual(m_assistantPoints.at(i).x, pos.x, 5) &&
+          areAlmostEqual(m_assistantPoints.at(i).y, pos.y, 5)) {
+        m_assistantPoints.erase(m_assistantPoints.begin() + i);
+        deletedPoint     = true;
+        TRectD pointRect = TRectD(pos.x - 3, pos.y - 3, pos.x + 3, pos.y + 3);
+        invalidate(pointRect);
+        break;
+      }
+    }
+    if (!deletedPoint) m_assistantPoints.push_back(pos);
+    simLevel->getProperties()->setVanishingPoints(m_assistantPoints);
+    level->setDirtyFlag(true);
     return;
   }
   if (e.isAltPressed() && e.isShiftPressed() && !e.isCtrlPressed()) {
@@ -403,27 +422,40 @@ void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
 
       // let's get info about our current location
       double denominator = m_lastPoint.x - m_firstPoint.x;
-      if (denominator == 0) denominator == 0.001;
-      double slope = ((m_lastPoint.y - m_firstPoint.y) / denominator);
+      double numerator   = m_lastPoint.y - m_firstPoint.y;
+      if (areAlmostEqual(denominator, 0.0, 0.0001)) {
+        denominator = denominator < 0 ? -0.0001 : 0.0001;
+      }
+      if (areAlmostEqual(numerator, 0.0, 0.0001)) {
+        numerator = numerator < 0 ? -0.0001 : 0.0001;
+      }
+      double slope = (numerator / denominator);
       double angle = std::atan(slope) * (180 / 3.14159);
 
       // now let's get the angle of each of the assistant points
       std::vector<double> anglesToAssistants;
       for (auto point : m_assistantPoints) {
         double newDenominator = point.x - m_firstPoint.x;
-        if (newDenominator == 0) newDenominator == 0.001;
-        double newSlope = ((point.y - m_firstPoint.y) / newDenominator);
+        double newNumerator   = point.y - m_firstPoint.y;
+        if (areAlmostEqual(newDenominator, 0.0, 0.0001)) {
+          newDenominator = newDenominator < 0 ? -0.0001 : 0.0001;
+        }
+        if (areAlmostEqual(newNumerator, 0.0, 0.0001)) {
+          newNumerator = newNumerator < 0 ? -0.0001 : 0.0001;
+        }
+
+        double newSlope = (newNumerator / newDenominator);
         double newAngle = std::atan(newSlope) * (180 / 3.14159);
         anglesToAssistants.push_back(newAngle);
       }
 
       // figure out which angle is closer
-      TPointD pointToUse = TPointD();
+      TPointD pointToUse = TPointD(0.0, 0.0);
       double difference  = 360;
       for (int i = 0; i < anglesToAssistants.size(); i++) {
         double newDifference = abs(angle - anglesToAssistants.at(i));
-        if (newDifference < difference) {
-          difference = newDifference;
+        if (newDifference < difference || (180 - newDifference) < difference) {
+          difference = std::min(newDifference, (180 - newDifference));
           pointToUse = m_assistantPoints.at(i);
         }
       }
@@ -755,6 +787,16 @@ void FullColorBrushTool::setWorkAndBackupImages() {
 
   m_strokeRect.empty();
   m_lastRect.empty();
+
+  TXshLevelHandle *level = getApplication()->getCurrentLevel();
+  TXshSimpleLevel *sl;
+  if (level) sl = level->getSimpleLevel();
+  if (sl) {
+    if (sl->getProperties()->getVanishingPoints() != m_assistantPoints) {
+      m_assistantPoints = sl->getProperties()->getVanishingPoints();
+      invalidate();
+    }
+  }
 }
 
 //------------------------------------------------------------------

--- a/toonz/sources/tnztools/fullcolorbrushtool.h
+++ b/toonz/sources/tnztools/fullcolorbrushtool.h
@@ -126,6 +126,9 @@ protected:
   bool m_isStraight = false;
   TPointD m_firstPoint;
   TPointD m_lastPoint;
+  std::vector<TPointD> m_assistantPoints;
+  bool m_addingAssistant = false;
+  bool m_snapAssistant   = false;
 
   bool m_propertyUpdating = false;
 };

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1468,19 +1468,20 @@ void ToonzRasterBrushTool::leftButtonDrag(const TPointD &pos,
                     std::pow((pointToUse.y - m_firstPoint.y), 2));
 
       if (distanceFirstToAssistant == 0.0) distanceFirstToAssistant = 0.001;
+
       double ratio = distanceFirstToLast / distanceFirstToAssistant;
-      double newX  = ((1 - ratio) * m_firstPoint.x) + (ratio * pointToUse.x);
-      double newY  = ((1 - ratio) * m_firstPoint.y) + (ratio * pointToUse.y);
+
+      double newX;
+      double newY;
 
       // flip the direction if the last point is farther than the first point
       if (distanceFirstToAssistant < distanceLastToAssistant &&
           distanceFirstToLast < distanceLastToAssistant) {
-        double xDistance    = m_lastPoint.x - m_firstPoint.x;
-        double yDistance    = m_lastPoint.y - m_firstPoint.y;
-        double newXDistance = newX - m_firstPoint.x;
-        double newYDistance = newY - m_firstPoint.y;
         newX = ((1 + ratio) * m_firstPoint.x) - (ratio * pointToUse.x);
         newY = ((1 + ratio) * m_firstPoint.y) - (ratio * pointToUse.y);
+      } else {
+        newX = ((1 - ratio) * m_firstPoint.x) + (ratio * pointToUse.x);
+        newY = ((1 - ratio) * m_firstPoint.y) + (ratio * pointToUse.y);
       }
 
       m_lastPoint = TPointD(newX, newY);

--- a/toonz/sources/tnztools/toonzrasterbrushtool.h
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.h
@@ -226,6 +226,9 @@ protected:
   bool m_propertyUpdating = false;
 
   bool m_isStraight = false;
+  std::vector<TPointD> m_assistantPoints;
+  bool m_addingAssistant = false;
+  bool m_snapAssistant   = false;
   TPointD m_firstPoint;
   TPointD m_lastPoint;
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -3305,7 +3305,6 @@ void MainWindow::toggleStatusBar(bool on) {
     m_statusBar->show();
     ShowStatusBarAction = 1;
   }
-  m_statusBar->showMessage("Hi John.", 5000);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/sceneviewerevents.cpp
+++ b/toonz/sources/toonz/sceneviewerevents.cpp
@@ -1617,8 +1617,9 @@ void SceneViewer::keyPressEvent(QKeyEvent *event) {
 
     if (key == Qt::Key_Shift || key == Qt::Key_Control || key == Qt::Key_Alt ||
         key == Qt::Key_AltGr) {
-      // quando l'utente preme shift/ctrl ecc. alcuni tool (es. pinch) devono
-      // cambiare subito la forma del cursore, senza aspettare il prossimo move
+      // when the user presses shift / ctrl etc. some tools (eg pinch) must
+      // immediately change the shape of the cursor, without waiting for the
+      // next move
       TMouseEvent toonzEvent;
       initToonzEvent(toonzEvent, event);
       toonzEvent.m_pos = TPointD(m_lastMousePos.x(),
@@ -1704,8 +1705,9 @@ void SceneViewer::keyReleaseEvent(QKeyEvent *event) {
 
   if (key == Qt::Key_Shift || key == Qt::Key_Control || key == Qt::Key_Alt ||
       key == Qt::Key_AltGr) {
-    // quando l'utente preme shift/ctrl ecc. alcuni tool (es. pinch) devono
-    // cambiare subito la forma del cursore, senza aspettare il prossimo move
+    // when the user presses shift / ctrl etc. some tools (eg pinch)
+    // must immediately change the shape of the cursor, without waiting for the
+    // next move
     TMouseEvent toonzEvent;
     initToonzEvent(toonzEvent, event);
     toonzEvent.m_pos = TPointD(m_lastMousePos.x(),

--- a/toonz/sources/toonzlib/rasterstrokegenerator.cpp
+++ b/toonz/sources/toonzlib/rasterstrokegenerator.cpp
@@ -44,7 +44,8 @@ void RasterStrokeGenerator::add(const TThickPoint &p) {
 //-----------------------------------------------------------
 
 // Disegna il tratto interamente
-void RasterStrokeGenerator::generateStroke(bool isPencil) const {
+void RasterStrokeGenerator::generateStroke(bool isPencil,
+                                           bool isStraight) const {
   std::vector<TThickPoint> points(m_points);
   int size = points.size();
   // Prende un buffer trasparente di appoggio
@@ -62,8 +63,13 @@ void RasterStrokeGenerator::generateStroke(bool isPencil) const {
     placeOver(m_raster, rasBuffer, newOrigin);
   } else if (size <= 3) {
     std::vector<TThickPoint> partialPoints;
-    partialPoints.push_back(points[0]);
-    partialPoints.push_back(points[1]);
+    if (isStraight && size == 3) {
+      partialPoints.push_back(points[0]);
+      partialPoints.push_back(points[2]);
+    } else {
+      partialPoints.push_back(points[0]);
+      partialPoints.push_back(points[1]);
+    }
     rasterBrush(rasBuffer, partialPoints, m_styleId, !isPencil);
     placeOver(m_raster, rasBuffer, newOrigin);
   } else if (size % 2 == 1) /*-- 奇数の場合 --*/

--- a/toonz/sources/toonzlib/txshsimplelevel.cpp
+++ b/toonz/sources/toonzlib/txshsimplelevel.cpp
@@ -905,6 +905,14 @@ void TXshSimpleLevel::loadData(TIStream &is) {
         int whiteTransp                      = 0;
         int antialiasSoftness                = 0;
         int isStopMotionLevel                = 0;
+        double vanishingPoint1x              = 0.0;
+        double vanishingPoint1y              = 0.0;
+        double vanishingPoint2x              = 0.0;
+        double vanishingPoint2y              = 0.0;
+        double vanishingPoint3x              = 0.0;
+        double vanishingPoint3y              = 0.0;
+        double vanishingPoint4x              = 0.0;
+        double vanishingPoint4y              = 0.0;
         LevelProperties::DpiPolicy dpiPolicy = LevelProperties::DP_ImageDpi;
         if (is.getTagParam("dpix", v)) xdpi = std::stod(v);
         if (is.getTagParam("dpiy", v)) ydpi = std::stod(v);
@@ -919,6 +927,41 @@ void TXshSimpleLevel::loadData(TIStream &is) {
         if (is.getTagParam("isStopMotionLevel", v))
           isStopMotionLevel = std::stoi(v);
 
+        if (is.getTagParam("vanishingPoint1x", v))
+          vanishingPoint1x = std::stod(v);
+        if (is.getTagParam("vanishingPoint1y", v))
+          vanishingPoint1y = std::stod(v);
+        if (is.getTagParam("vanishingPoint2x", v))
+          vanishingPoint2x = std::stod(v);
+        if (is.getTagParam("vanishingPoint2y", v))
+          vanishingPoint2y = std::stod(v);
+        if (is.getTagParam("vanishingPoint3x", v))
+          vanishingPoint3x = std::stod(v);
+        if (is.getTagParam("vanishingPoint3y", v))
+          vanishingPoint3y = std::stod(v);
+        if (is.getTagParam("vanishingPoint4x", v))
+          vanishingPoint4x = std::stod(v);
+        if (is.getTagParam("vanishingPoint4y", v))
+          vanishingPoint4y = std::stod(v);
+
+        std::vector<TPointD> vanishingPoints;
+        if (vanishingPoint1x != 0.0 && vanishingPoint1y != 0.0) {
+          vanishingPoints.push_back(
+              TPointD(vanishingPoint1x, vanishingPoint1y));
+        }
+        if (vanishingPoint2x != 0.0 && vanishingPoint2y != 0.0) {
+          vanishingPoints.push_back(
+              TPointD(vanishingPoint2x, vanishingPoint2y));
+        }
+        if (vanishingPoint3x != 0.0 && vanishingPoint2y != 0.0) {
+          vanishingPoints.push_back(
+              TPointD(vanishingPoint3x, vanishingPoint3y));
+        }
+        if (vanishingPoint4x != 0.0 && vanishingPoint2y != 0.0) {
+          vanishingPoints.push_back(
+              TPointD(vanishingPoint4x, vanishingPoint4y));
+        }
+
         m_properties->setDpiPolicy(dpiPolicy);
         m_properties->setDpi(TPointD(xdpi, ydpi));
         m_properties->setSubsampling(subsampling);
@@ -926,6 +969,7 @@ void TXshSimpleLevel::loadData(TIStream &is) {
         m_properties->setDoAntialias(antialiasSoftness);
         m_properties->setWhiteTransp(whiteTransp);
         m_properties->setIsStopMotion(isStopMotionLevel);
+        m_properties->setVanishingPoints(vanishingPoints);
         if (isStopMotionLevel == 1) setIsReadOnly(true);
       } else
         throw TException("unexpected tag " + tagName);
@@ -1371,6 +1415,27 @@ void TXshSimpleLevel::saveData(TOStream &os) {
   } else if (getProperties()->isStopMotionLevel()) {
     attr["isStopMotionLevel"] =
         std::to_string(getProperties()->isStopMotionLevel());
+  } else if (getProperties()->getVanishingPoints().size() > 0) {
+    std::vector<TPointD> vanishingPoints =
+        getProperties()->getVanishingPoints();
+    int size = vanishingPoints.size();
+
+    if (size > 0) {
+      attr["vanishingPoint1x"] = std::to_string(vanishingPoints.at(0).x);
+      attr["vanishingPoint1y"] = std::to_string(vanishingPoints.at(0).y);
+    }
+    if (size > 1) {
+      attr["vanishingPoint2x"] = std::to_string(vanishingPoints.at(1).x);
+      attr["vanishingPoint2y"] = std::to_string(vanishingPoints.at(1).y);
+    }
+    if (size > 2) {
+      attr["vanishingPoint3x"] = std::to_string(vanishingPoints.at(2).x);
+      attr["vanishingPoint3y"] = std::to_string(vanishingPoints.at(2).y);
+    }
+    if (size > 3) {
+      attr["vanishingPoint4x"] = std::to_string(vanishingPoints.at(3).x);
+      attr["vanishingPoint4y"] = std::to_string(vanishingPoints.at(3).y);
+    }
   }
 
   if (m_type == TZI_XSHLEVEL) attr["type"] = "s";

--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -1112,10 +1112,9 @@ void TStyleSelection::pasteStylesValues(bool pasteName, bool pasteColor) {
       TCleanupStyle *cleanupStyle =
           dynamic_cast<TCleanupStyle *>(data->getStyle(i));
       if (cleanupStyle && !palette->isCleanupPalette())
-        if (cleanupStyle)
-          palette->setStyle(styleId, cleanupStyle->getMainColor());
-        else
-          palette->setStyle(styleId, data->getStyle(i)->clone());
+        palette->setStyle(styleId, cleanupStyle->getMainColor());
+      else
+        palette->setStyle(styleId, data->getStyle(i)->clone());
 
       // Process the global and original names according to the pasted style
       TColorStyle *pastedStyle = getPalette()->getStyle(styleId);


### PR DESCRIPTION
This adds a perspective assistant for the brush tool in Smart Raster and Raster levels.

To use this;
With the brush tool active:
Alt + Ctrl + Click to set a vanishing point. (Multiple points are supported)

Hold Alt while drawing to snap to perspective drawing.  The assistant will figure out which vanishing point you are aiming for.

To clear the points - Shift + Alt + Click.

If no vanishing point is placed, it will use the center as a vanishing point.
