### PR TITLE
Fix weird dockinig issues

### DIFF
--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -48,7 +48,7 @@ public:
   void setName(QString name) { m_name = name; }
 
   void save();
-  void load(const TFilePath &fp);
+  std::pair<DockLayout *, DockLayout::State> load(const TFilePath &fp);
 };
 
 //-----------------------------------------------------------------------------
@@ -71,6 +71,7 @@ class MainWindow final : public QMainWindow {
 
   /*-- show layout name in the title bar --*/
   QString m_layoutName;
+  std::vector<std::pair<DockLayout *, DockLayout::State>> m_panelStates;
 
 public:
 #if QT_VERSION >= 0x050500

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -421,55 +421,14 @@ void DockLayout::applyTransform(const QTransform &transform) {
 }
 
 //------------------------------------------------------
-// check if the region will be with fixed width
-bool Region::checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets) {
-  if (m_item) {
-    if ((m_item->objectName() == "FilmStrip" && m_item->getCanFixWidth()) ||
-        m_item->objectName() == "StyleEditor" ||
-        m_item->objectName() == "StopMotionController") {
-      widgets.push_back(m_item);
-      return true;
-    } else
-      return false;
-  }
-  if (m_childList.empty()) return false;
-  // for horizontal orientation, return true if all items are to be fixed
-  if (m_orientation == horizontal) {
-    bool ret = true;
-    for (Region *childRegion : m_childList) {
-      if (!childRegion->checkWidgetsToBeFixedWidth(widgets)) ret = false;
-    }
-    return ret;
-  }
-  // for vertical orientation, return true if at least one item is to be fixed
-  else {
-    bool ret = false;
-    for (Region *childRegion : m_childList) {
-      if (childRegion->checkWidgetsToBeFixedWidth(widgets)) ret = true;
-    }
-    return ret;
-  }
-}
-
-//------------------------------------------------------
 
 void DockLayout::redistribute() {
   if (!m_regions.empty()) {
-    std::vector<QWidget *> widgets;
+    // std::vector<QWidget *> widgets;
 
     // Recompute extremal region sizes
     // NOTA: Sarebbe da fare solo se un certo flag lo richiede; altrimenti tipo
     // per resize events e' inutile...
-
-    // let's force the width of the film strip / style editor not to change
-    // check recursively from the root region, if the widgets can be fixed.
-    // it avoids all widgets in horizontal alignment to be fixed, or UI becomes
-    // glitchy.
-    bool widgetsCanBeFixedWidth =
-        !m_regions.front()->checkWidgetsToBeFixedWidth(widgets);
-    if (widgetsCanBeFixedWidth) {
-      for (QWidget *widget : widgets) widget->setFixedWidth(widget->width());
-    }
 
     m_regions.front()->calculateExtremalSizes();
 
@@ -487,13 +446,6 @@ void DockLayout::redistribute() {
     // Recompute Layout geometry
     m_regions.front()->setGeometry(contentsRect());
     m_regions.front()->redistribute();
-
-    if (widgetsCanBeFixedWidth) {
-      for (QWidget *widget : widgets) {
-        widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
-        widget->setMinimumSize(0, 0);
-      }
-    }
   }
 
   // Finally, apply Region geometries found

--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -530,8 +530,6 @@ public:
 
   unsigned int find(const Region *subRegion) const;
 
-  bool checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets);
-
 private:
   // Setters - private
   void setOrientation(bool orientation) { m_orientation = orientation; }


### PR DESCRIPTION
Found another way to fix level strip and style editor resizing on restoring that doesn't seem to allow docks to get docked in weird ways.