### PR TITLE
Fix resizing panels again

### DIFF
--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1303,10 +1303,12 @@ void MainWindow::showEvent(QShowEvent *event) {
   nt->setInterval(10);
 
   connect(nt, &QTimer::timeout, [=]() {
+#ifdef WIN32
     int roomsSize = m_panelStates.size();
     for (auto iter : m_panelStates) {
       iter.first->restoreState(iter.second);
     }
+#endif
   });
   nt->connect(nt, SIGNAL(timeout()), SLOT(deleteLater()));
 

--- a/toonz/sources/toonz/startuppopup.cpp
+++ b/toonz/sources/toonz/startuppopup.cpp
@@ -860,7 +860,13 @@ void StartupPopup::onSceneChanged() {
   if (!TApp::instance()->getCurrentScene()->getScene()->isUntitled()) {
     hide();
   } else {
-    // updateProjectCB();
+    TFilePath path = TApp::instance()
+                         ->getCurrentScene()
+                         ->getScene()
+                         ->getProject()
+                         ->getProjectFolder();
+    std::string pathStr = path.getQString().toStdString();
+    m_projectLocationFld->setPath(path.getQString());
   }
 }
 

--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -421,14 +421,64 @@ void DockLayout::applyTransform(const QTransform &transform) {
 }
 
 //------------------------------------------------------
+// check if the region will be with fixed width
+bool Region::checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets,
+                                        bool &fromDocking) {
+  if (m_item) {
+    if (m_item->wasFloating()) {
+      fromDocking = true;
+      m_item->clearWasFloating();
+      return false;
+    }
+    if ((m_item->objectName() == "FilmStrip" && m_item->getCanFixWidth()) ||
+        m_item->objectName() == "StyleEditor" ||
+        m_item->objectName() == "StopMotionController") {
+      widgets.push_back(m_item);
+      return true;
+    } else
+      return false;
+  }
+  if (m_childList.empty()) return false;
+  // for horizontal orientation, return true if all items are to be fixed
+  if (m_orientation == horizontal) {
+    bool ret = true;
+    for (Region *childRegion : m_childList) {
+      if (!childRegion->checkWidgetsToBeFixedWidth(widgets, fromDocking))
+        ret = false;
+    }
+    return ret;
+  }
+  // for vertical orientation, return true if at least one item is to be fixed
+  else {
+    bool ret = false;
+    for (Region *childRegion : m_childList) {
+      if (childRegion->checkWidgetsToBeFixedWidth(widgets, fromDocking))
+        ret = true;
+    }
+    return ret;
+  }
+}
+
+//------------------------------------------------------
 
 void DockLayout::redistribute() {
   if (!m_regions.empty()) {
-    // std::vector<QWidget *> widgets;
+    std::vector<QWidget *> widgets;
 
     // Recompute extremal region sizes
     // NOTA: Sarebbe da fare solo se un certo flag lo richiede; altrimenti tipo
     // per resize events e' inutile...
+
+    // let's force the width of the film strip / style editor not to change
+    // check recursively from the root region, if the widgets can be fixed.
+    // it avoids all widgets in horizontal alignment to be fixed, or UI becomes
+    // glitchy.
+    bool fromDocking = false;
+    bool widgetsCanBeFixedWidth =
+        !m_regions.front()->checkWidgetsToBeFixedWidth(widgets, fromDocking);
+    if (!fromDocking && widgetsCanBeFixedWidth) {
+      for (QWidget *widget : widgets) widget->setFixedWidth(widget->width());
+    }
 
     m_regions.front()->calculateExtremalSizes();
 
@@ -446,6 +496,13 @@ void DockLayout::redistribute() {
     // Recompute Layout geometry
     m_regions.front()->setGeometry(contentsRect());
     m_regions.front()->redistribute();
+
+    if (!fromDocking && widgetsCanBeFixedWidth) {
+      for (QWidget *widget : widgets) {
+        widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+        widget->setMinimumSize(0, 0);
+      }
+    }
   }
 
   // Finally, apply Region geometries found
@@ -690,7 +747,8 @@ Region *DockLayout::dockItemPrivate(DockWidget *item, Region *r, int idx) {
   item->onDock(true);
 
   item->setDockedAppearance();
-  item->m_floating = false;
+  item->m_floating    = false;
+  item->m_wasFloating = true;
 
   if (!r) {
     // Insert new root region

--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -176,7 +176,8 @@ public:
 
 protected:
   // Private attributes for dragging purposes
-  bool m_floating;   // Whether this window is floating or docked
+  bool m_floating;  // Whether this window is floating or docked
+  bool m_wasFloating;
   bool m_dragging;   // Whether this window is being dragged
   bool m_undocking;  // Still docked, but after a mouse button press on a title
                      // bar.
@@ -220,6 +221,8 @@ public:
   DockLayout *parentLayout() const { return m_parentLayout; }
 
   bool isFloating() const { return m_floating; }
+  bool wasFloating() const { return m_wasFloating; }
+  void clearWasFloating() { m_wasFloating = false; }
   bool isMaximized() const { return m_maximized; }
 
   // Query functions
@@ -529,6 +532,9 @@ public:
   DockPlaceholder *placeholder(int i) const { return m_placeholders[i]; }
 
   unsigned int find(const Region *subRegion) const;
+
+  bool checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets,
+                                  bool &fromDocking);
 
 private:
   // Setters - private


### PR DESCRIPTION
This is another attempt at fixing the ongoing docking issues and panel resizing issues.

This will not set a fixed width for any panels if a panel is being docked.  This should fix the strange docking issues.

This will set fixed widths for the level strip, style editor and stop motion control panel if the window is being resized.

It looks like a bigger commit than it is, since I am putting back code that I took out before.