### PR TITLE
Add Delete Frame Command to Level Strip

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -106,6 +106,7 @@
         <command>MI_ExportLevel</command>
         <separator/>
         <command>MI_AddFrames</command>
+        <command>MI_ClearFrames</command>
         <command>MI_Renumber</command>
         <command>MI_ReplaceLevel</command>
         <command>MI_RevertToCleanedUp</command>

--- a/toonz/sources/include/toonzqt/selectioncommandids.h
+++ b/toonz/sources/include/toonzqt/selectioncommandids.h
@@ -17,6 +17,7 @@
 #define MI_ToggleLinkToStudioPalette "MI_ToggleLinkToStudioPalette"
 #define MI_RemoveReferenceToStudioPalette "MI_RemoveReferenceToStudioPalette"
 #define MI_Clear "MI_Clear"
+#define MI_ClearFrames "MI_ClearFrames"
 #define MI_SelectAll "MI_SelectAll"
 #define MI_InvertSelection "MI_InvertSelection"
 

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1244,6 +1244,7 @@ void FilmstripFrames::contextMenuEvent(QContextMenuEvent *event) {
     menu->addAction(cm->getAction(MI_PasteInto));
     menu->addAction(cm->getAction(MI_Insert));
     menu->addAction(cm->getAction(MI_Clear));
+    menu->addAction(cm->getAction(MI_ClearFrames));
     menu->addSeparator();
     menu->addAction(cm->getAction(MI_Reverse));
     menu->addAction(cm->getAction(MI_Swing));

--- a/toonz/sources/toonz/filmstripcommand.h
+++ b/toonz/sources/toonz/filmstripcommand.h
@@ -31,6 +31,7 @@ void paste(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void merge(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void pasteInto(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void cut(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
+void deleteFrames(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void clear(TXshSimpleLevel *sl, std::set<TFrameId> &frames);
 void insert(TXshSimpleLevel *sl, const std::set<TFrameId> &frames,
             bool withUndo);

--- a/toonz/sources/toonz/filmstripselection.h
+++ b/toonz/sources/toonz/filmstripselection.h
@@ -50,6 +50,7 @@ public:
   void mergeFrames();
   void pasteInto();
   void deleteFrames();
+  void clearFrames();
   void insertEmptyFrames();
   void addFrames();
   void reverseFrames();

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1877,6 +1877,7 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(MI_RemoveReferenceToStudioPalette,
                              tr("Remove Reference to Studio Palette"), "");
   createMenuEditAction(MI_Clear, tr("&Delete"), "Del");
+  createMenuEditAction(MI_ClearFrames, tr("&Clear Frames"), "");
   createMenuEditAction(MI_Insert, tr("&Insert"), "Ins");
   createMenuEditAction(MI_InsertAbove, tr("&Insert Above/After"), "Shift+Ins");
   createMenuEditAction(MI_Group, tr("&Group"), "Ctrl+G");

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -487,6 +487,7 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(levelMenu, MI_ExportLevel);
   levelMenu->addSeparator();
   addMenuItem(levelMenu, MI_AddFrames);
+  addMenuItem(levelMenu, MI_ClearFrames);
   addMenuItem(levelMenu, MI_Renumber);
   addMenuItem(levelMenu, MI_ReplaceLevel);
   addMenuItem(levelMenu, MI_RevertToCleanedUp);


### PR DESCRIPTION
This renames the current "delete" command in the level strip to "Clear Frames" and creates an actual delete frames command for the level strip.