### PR TITLE
Allow Changing Parent of Column from XSheet

### DIFF
--- a/toonz/sources/toonz/xshcolumnviewer.h
+++ b/toonz/sources/toonz/xshcolumnviewer.h
@@ -89,6 +89,7 @@ public:
 
 protected:
   void mouseMoveEvent(QMouseEvent *event) override;
+  void wheelEvent(QWheelEvent *event) override;
   void focusOutEvent(QFocusEvent *e) override;
   void focusInEvent(QFocusEvent *e) override {}
   void selectCurrent(const QString &text);

--- a/toonz/sources/toonzqt/styleeditor.cpp
+++ b/toonz/sources/toonzqt/styleeditor.cpp
@@ -3427,12 +3427,20 @@ void StyleEditor::onStyleChanged(bool isDragging) {
   m_colorParameterSelector->setStyle(*m_editedStyle);
   m_settingsPage->setStyle(m_editedStyle);
   m_newColor->setStyle(*m_editedStyle);
-  TPixel32 color  = m_editedStyle->getMainColor();
-  QString myColor = QString::number(color.r) + ", " + QString::number(color.g) +
-                    ", " + QString::number(color.b);
-  std::string myColorStr = myColor.toStdString();
-  QString styleSheet     = "background-color: rgb(%1);";
-  m_fillColorWidget->setStyleSheet(styleSheet.arg(myColor));
+  int tag = m_editedStyle->getTagId();
+  if (tag == 4 || tag == 2000 || tag == 2800) {
+    m_fillColorWidget->hide();
+  } else {
+    m_fillColorWidget->show();
+
+    TPixel32 color  = m_editedStyle->getMainColor();
+    QString myColor = QString::number(color.r) + ", " +
+                      QString::number(color.g) + ", " +
+                      QString::number(color.b);
+    std::string myColorStr = myColor.toStdString();
+    QString styleSheet     = "background-color: rgb(%1);";
+    m_fillColorWidget->setStyleSheet(styleSheet.arg(myColor));
+  }
   m_oldColor->setStyle(
       *m_oldStyle);  // This line is needed for proper undo behavior
 }
@@ -3530,13 +3538,19 @@ void StyleEditor::onColorChanged(const ColorModel &color, bool isDragging) {
     }
 
     m_newColor->setStyle(*m_editedStyle);
-    TPixel32 color  = m_editedStyle->getMainColor();
-    QString myColor = QString::number(color.r) + ", " +
-                      QString::number(color.g) + ", " +
-                      QString::number(color.b);
-    std::string myColorStr = myColor.toStdString();
-    QString styleSheet     = "background-color: rgb(%1);";
-    m_fillColorWidget->setStyleSheet(styleSheet.arg(myColor));
+    int tag = m_editedStyle->getTagId();
+    if (tag == 4 || tag == 2000 || tag == 2800) {
+      m_fillColorWidget->hide();
+    } else {
+      m_fillColorWidget->show();
+      TPixel32 color  = m_editedStyle->getMainColor();
+      QString myColor = QString::number(color.r) + ", " +
+                        QString::number(color.g) + ", " +
+                        QString::number(color.b);
+      std::string myColorStr = myColor.toStdString();
+      QString styleSheet     = "background-color: rgb(%1);";
+      m_fillColorWidget->setStyleSheet(styleSheet.arg(myColor));
+    }
     m_colorParameterSelector->setStyle(*m_editedStyle);
 
     if (m_autoButton->isChecked()) {
@@ -3678,14 +3692,20 @@ bool StyleEditor::setStyle(TColorStyle *currentStyle) {
     m_plainColorPage->setColor(*currentStyle, getColorParam());
     m_oldColor->setStyle(*currentStyle);
     m_newColor->setStyle(*currentStyle);
-    TPixel32 color  = currentStyle->getMainColor();
-    QString myColor = QString::number(color.r) + ", " +
-                      QString::number(color.g) + ", " +
-                      QString::number(color.b);
-    std::string myColorStr = myColor.toStdString();
-    QString styleSheet     = "background-color: rgb(%1);";
-    m_fillColorWidget->setStyleSheet(styleSheet.arg(myColor));
 
+    int tag = currentStyle->getTagId();
+    if (tag == 4 || tag == 2000 || tag == 2800) {
+      m_fillColorWidget->hide();
+    } else {
+      m_fillColorWidget->show();
+      TPixel32 color  = currentStyle->getMainColor();
+      QString myColor = QString::number(color.r) + ", " +
+                        QString::number(color.g) + ", " +
+                        QString::number(color.b);
+      std::string myColorStr = myColor.toStdString();
+      QString styleSheet     = "background-color: rgb(%1);";
+      m_fillColorWidget->setStyleSheet(styleSheet.arg(myColor));
+    }
     setOldStyleToStyle(currentStyle);
   }
 


### PR DESCRIPTION
This allows the user to change the parent of a column from the xsheet header.  You can also change the port a column is connected to.  These features are in Toonz, but were removed in OpenToonz.

This also shows the parent's name if it has been changed instead of "Col1" 

![newHeader](https://user-images.githubusercontent.com/4576381/86317955-f3ca8300-bbed-11ea-92df-003db0056c81.PNG)
