### PR TITLE
Fix incorrectly using None interpolation type

### DIFF
--- a/toonz/sources/common/tparam/tdoubleparam.cpp
+++ b/toonz/sources/common/tparam/tdoubleparam.cpp
@@ -757,6 +757,9 @@ void TDoubleParam::setKeyframe(int index, const TDoubleKeyframe &k) {
     dst.m_prevType = TDoubleKeyframe::None;
   else
     dst.m_prevType = keyframes[index - 1].m_type;
+
+  if (getKeyframeCount() - 1 != index)
+    keyframes[index + 1].m_prevType = dst.m_type;
 }
 
 //---------------------------------------------------------
@@ -827,6 +830,8 @@ void TDoubleParam::setKeyframe(const TDoubleKeyframe &k) {
     it->m_prevType = TDoubleKeyframe::None;
   else
     it->m_prevType = it[-1].m_type;
+
+  if (it + 1 != keyframes.end()) it[1].m_prevType = it->m_type;
 
   m_imp->notify(TParamChange(this, 0, 0, true, false, false));
 
@@ -1148,6 +1153,8 @@ is >> m_imp->m_defaultValue;
       while (!is.eos()) {
         TDoubleKeyframe kk;
         kk.loadData(is);
+        // Throw out invalid interpolation types
+        if (kk.m_type == TDoubleKeyframe::None) continue;
         TActualDoubleKeyframe k(kk);
         k.m_expression.setGrammar(m_imp->m_grammar);
         k.m_expression.setOwnerParameter(this);


### PR DESCRIPTION
This PR fixes an problem in Tahoma that also exists in the Official OpenToonz version noted in issue https://github.com/opentoonz/opentoonz/issues/3168

When a new keyframe is created, the keyframe may inadvertently be created as a `None` interpolation type. There may be multiple ways to do this, but 1 known way is to create a new keyframe before the 1st keyframe in the column and then copy/paste the newly created keyframe after it.  This was due to not updating `m_prevType` in the next keyframe properly.

A `None` interpolation keyframe is written to the scene file as `<n>...<\n>` which can lead to a crash while loading the scene or create strange behavior with the keyframes in the column.

This fix should
1. Prevent the creation of a `None` interpolation type keyframe
2. Throw out `None` interpolation keyframes when loading the scene in case it encounters one.
