### PR TITLE
Remove Letter Ports

### DIFF
--- a/toonz/sources/include/toonzqt/stageschematicnode.h
+++ b/toonz/sources/include/toonzqt/stageschematicnode.h
@@ -209,6 +209,7 @@ protected:
 
 class StageSchematicNodePort final : public SchematicPort {
   QString m_handle;
+  bool m_canShowNumbers = true;
 
 public:
   StageSchematicNodePort(StageSchematicNodeDock *parent, int type);
@@ -221,6 +222,8 @@ public:
   QString getHandle() { return m_handle; }
 
   bool linkTo(SchematicPort *port, bool checkOnly = false) override;
+
+  void setCanShowNumbers(bool canShowNumbers);
 
 private:
   SchematicPort *searchPort(const QPointF &scenePos) override;
@@ -375,10 +378,12 @@ protected:
   bool m_isGroup;
   QString m_name;
   SchematicName *m_nameItem;
+  bool m_canShowNumbers = true;
 
 public:
   StageSchematicNode(StageSchematicScene *scene, TStageObject *obj, int width,
-                     int height, bool isGroup = false);
+                     int height, bool isGroup = false,
+                     bool canShowNumbers = true);
   ~StageSchematicNode();
 
   void setWidth(const qreal &width) { m_width = width; }
@@ -398,6 +403,7 @@ public:
   StageSchematicNodePort *makeParentPort(const QString &label);
   virtual void updateChildDockPositions();  // TODO: commento! doxygen
   void setPosition(const QPointF &newPos) override;
+  bool getCanShowNumbers() { return m_canShowNumbers; }
 
 signals:
   void currentObjectChanged(const TStageObjectId &id, bool isSpline);

--- a/toonz/sources/toonz/xsheetviewer.cpp
+++ b/toonz/sources/toonz/xsheetviewer.cpp
@@ -1491,6 +1491,12 @@ void XsheetViewer::scrollToVerticalRange(int y0, int y1) {
 
 //-----------------------------------------------------------------------------
 
+int XsheetViewer::getColumnScrollValue() {
+  return m_columnScrollArea->horizontalScrollBar()->value();
+}
+
+//-----------------------------------------------------------------------------
+
 void XsheetViewer::onSelectionSwitched(TSelection *oldSelection,
                                        TSelection *newSelection) {
   if ((TSelection *)getCellSelection() == oldSelection) {

--- a/toonz/sources/toonz/xsheetviewer.h
+++ b/toonz/sources/toonz/xsheetviewer.h
@@ -653,6 +653,7 @@ public:
   void setCurrentRow(int row);
 
   void scroll(QPoint delta);
+  int getColumnScrollValue();
 
   void setAutoPanSpeed(const QPoint &speed);
   void setAutoPanSpeed(const QRect &widgetBounds, const QPoint &mousePos);

--- a/toonz/sources/toonzlib/tstageobjecttree.cpp
+++ b/toonz/sources/toonzlib/tstageobjecttree.cpp
@@ -134,7 +134,8 @@ void TStageObjectTree::checkIntegrity() {
       columnIndexTable.insert(index);
     } else if (id.isPegbar()) {
       assert(imp->getParent() != TStageObjectId());
-      assert(imp->getParent().isPegbar() || imp->getParent().isTable());
+      assert(imp->getParent().isPegbar() || imp->getParent().isTable() ||
+             imp->getParent().isCamera());
     } else if (id.isTable())
       assert(imp->getParent() == TStageObjectId());
     else if (id.isCamera())  // la camera puo' essere attaccata dovunque


### PR DESCRIPTION
This removes the letter ports from the schematic (except for B - which now stands for Base).  Numbered ports are still available for parenting to hooks.  

This also fixes a visual glitch in the change parent and port popups in the xsheet.