### PR TITLE
Display Default Palette

### DIFF
--- a/toonz/sources/common/tvrender/tpalette.cpp
+++ b/toonz/sources/common/tvrender/tpalette.cpp
@@ -9,6 +9,8 @@
 #include "tsystem.h"
 #include "tstream.h"
 
+#include "toonz/txshleveltypes.h"
+
 // Qt includes
 #include <QMutexLocker>
 
@@ -246,7 +248,9 @@ TPalette::TPalette()
     , m_isLocked(false)
     , m_askOverwriteFlag(false)
     , m_shortcutScopeIndex(0)
-    , m_currentStyleId(1) {
+    , m_currentStyleId(1)
+    , m_isDefaultPalette(false)
+    , m_defaultPaletteType(UNKNOWN_XSHLEVEL) {
   QString tempName(QObject::tr("colors"));
   std::wstring pageName = tempName.toStdWString();
   Page *page            = addPage(pageName);

--- a/toonz/sources/include/toonz/palettecontroller.h
+++ b/toonz/sources/include/toonz/palettecontroller.h
@@ -25,6 +25,7 @@
 //    Forward declarations
 
 class TPaletteHandle;
+class TPalette;
 
 //=====================================================
 
@@ -50,6 +51,10 @@ class DVAPI PaletteController final : public QObject {
   TPixel32 m_colorSample;
   bool m_colorAutoApplyEnabled;
 
+  TPalette *m_defaultVector;
+  TPalette *m_defaultToonzRaster;
+  TPalette *m_defaultRaster;
+
 public:
   PaletteController();
   ~PaletteController();
@@ -63,6 +68,9 @@ public:
   TPaletteHandle *getCurrentPalette() const { return m_currentPalette; }
 
   void setCurrentPalette(TPaletteHandle *paletteHandle);
+
+  TPalette *getDefaultPalette(int levelType);
+  void setDefaultPalette(int levelType, TPalette *palette);
 
   // centralized handling of color auto-apply. see StyleEditor.
   // when ColorAutoApply is disabled then changes should made on the ColorSample

--- a/toonz/sources/include/toonz/studiopalette.h
+++ b/toonz/sources/include/toonz/studiopalette.h
@@ -77,6 +77,7 @@ public:
 
   TFilePath getLevelPalettesRoot();
   TFilePath getProjectPalettesRoot();
+  TFilePath getPersonalPalettesRoot();
 
   // TFilePath getRefImage(const TFilePath palettePath);
 

--- a/toonz/sources/include/toonz/toonzfolders.h
+++ b/toonz/sources/include/toonz/toonzfolders.h
@@ -29,6 +29,8 @@ DVAPI TFilePath getMyRoomsDir();
 DVAPI TFilePath getRoomsFile(TFilePath filename);
 DVAPI TFilePath getRoomsFile(std::string fn);
 
+DVAPI TFilePath getMyPalettesDir();
+
 // restituisce getMyModuleDir() + filename
 // o getTemplateModuleDir() + filename
 DVAPI TFilePath getModuleFile(TFilePath filename);

--- a/toonz/sources/include/toonzqt/paletteviewer.h
+++ b/toonz/sources/include/toonzqt/paletteviewer.h
@@ -169,6 +169,9 @@ protected slots:
   void setIsLocked(bool lock);
 
   void onSwitchToPage(int pageIndex);
+
+private:
+  void setSaveDefaultText(QAction *action, int levelType);
 };
 
 #endif  // PALETTEVIEWER_H

--- a/toonz/sources/include/tpalette.h
+++ b/toonz/sources/include/tpalette.h
@@ -194,6 +194,8 @@ private:
   int m_currentFrame;         //!< Palette's current frame in style animations.
   bool m_isCleanupPalette;    //!< Whether the palette is used for cleanup
                               //! purposes.
+  bool m_isDefaultPalette;   //!< Whether the palette is a level default palette
+  int m_defaultPaletteType;  //!< Indicates default palette's type
 
   TImageP m_refImg;
   TFilePath m_refImgPath;
@@ -354,6 +356,20 @@ between RGBA color components.
       bool on);  //!< Sets the palette's identity as a cleanup palette.
   bool isCleanupPalette() const {
     return m_isCleanupPalette;
+  }  //!< Returns whether this is a cleanup palette.
+
+  void setIsDefaultPalette(bool on) {
+    m_isDefaultPalette = on;
+  }  //!< Sets the palette's identity as a cleanup palette.
+  bool isDefaultPalette() const {
+    return m_isDefaultPalette;
+  }  //!< Returns whether this is a cleanup palette.
+
+  void setDefaultPaletteType(int levelType) {
+    m_defaultPaletteType = levelType;
+  }  //!< Sets the palette's identity as a cleanup palette.
+  int getDefaultPaletteType() const {
+    return m_defaultPaletteType;
   }  //!< Returns whether this is a cleanup palette.
 
   const TImageP &getRefImg() const {

--- a/toonz/sources/include/tpalette.h
+++ b/toonz/sources/include/tpalette.h
@@ -194,8 +194,8 @@ private:
   int m_currentFrame;         //!< Palette's current frame in style animations.
   bool m_isCleanupPalette;    //!< Whether the palette is used for cleanup
                               //! purposes.
-  bool m_isDefaultPalette;   //!< Whether the palette is a level default palette
-  int m_defaultPaletteType;  //!< Indicates default palette's type
+  bool m_isDefaultPalette;    //!< Whether the palette is a default palette
+  int m_defaultPaletteType;   //!< Indicates default palette's level type
 
   TImageP m_refImg;
   TFilePath m_refImgPath;
@@ -360,17 +360,17 @@ between RGBA color components.
 
   void setIsDefaultPalette(bool on) {
     m_isDefaultPalette = on;
-  }  //!< Sets the palette's identity as a cleanup palette.
+  }  //!< Sets the palette's identity as a default palette.
   bool isDefaultPalette() const {
     return m_isDefaultPalette;
-  }  //!< Returns whether this is a cleanup palette.
+  }  //!< Returns whether this is a default palette.
 
   void setDefaultPaletteType(int levelType) {
     m_defaultPaletteType = levelType;
-  }  //!< Sets the palette's identity as a cleanup palette.
+  }  //!< Sets the default palette's level type.
   int getDefaultPaletteType() const {
     return m_defaultPaletteType;
-  }  //!< Returns whether this is a cleanup palette.
+  }  //!< Returns the default palette's level type.
 
   const TImageP &getRefImg() const {
     return m_refImg;

--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -505,6 +505,12 @@ TImage *TTool::touchImage() {
   int levelType    = pref->getDefLevelType();
   TXshLevel *xl    = scene->createNewLevel(levelType);
   sl               = xl->getSimpleLevel();
+  if (levelType == TZP_XSHLEVEL || levelType == PLI_XSHLEVEL) {
+    TPalette *defaultPalette =
+        getApplication()->getPaletteController()->getDefaultPalette(levelType);
+    if (defaultPalette) sl->setPalette(defaultPalette->clone());
+  }
+
   m_isLevelCreated = true;
 
   // create the drawing

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -480,6 +480,10 @@ bool pasteStrokesInCellWithoutUndo(
       TXshLevel *xl     = scene->createNewLevel(PLI_XSHLEVEL);
       if (!xl) return false;
       sl = xl->getSimpleLevel();
+      TPalette *defaultPalette =
+          TApp::instance()->getPaletteController()->getDefaultPalette(
+              PLI_XSHLEVEL);
+      if (defaultPalette) sl->setPalette(defaultPalette->clone());
       assert(sl);
       app->getCurrentScene()->notifyCastChange();
     }
@@ -658,7 +662,13 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
       if (!xl) return false;
       isLevelCreated = true;
       sl             = xl->getSimpleLevel();
-      assert(sl);
+      if (levelType == TZP_XSHLEVEL) {
+        TPalette *defaultPalette =
+            TApp::instance()->getPaletteController()->getDefaultPalette(
+                levelType);
+        if (defaultPalette) sl->setPalette(defaultPalette->clone());
+      }
+	  assert(sl);
       app->getCurrentScene()->notifyCastChange();
 
       if (levelType == TZP_XSHLEVEL || levelType == OVL_XSHLEVEL) {
@@ -2837,6 +2847,13 @@ static void createNewDrawing(TXsheet *xsh, int row, int col,
     // no level found. create it
     TXshLevel *xl = xsh->getScene()->createNewLevel(preferredLevelType);
     sl            = xl->getSimpleLevel();
+    if (preferredLevelType == TZP_XSHLEVEL ||
+        preferredLevelType == PLI_XSHLEVEL) {
+      TPalette *defaultPalette =
+          TApp::instance()->getPaletteController()->getDefaultPalette(
+              preferredLevelType);
+      if (defaultPalette) sl->setPalette(defaultPalette->clone());
+    }
     TApp::instance()->getCurrentScene()->notifyCastChange();
     levelCreated = true;
   } else {
@@ -3271,6 +3288,9 @@ TXshSimpleLevel *TCellSelection::getNewToonzRasterLevel(
   TXshLevel *level =
       scene->createNewLevel(TZP_XSHLEVEL, newName, TDimension(), 0, fp);
   TXshSimpleLevel *sl = dynamic_cast<TXshSimpleLevel *>(level);
+  TPalette *defaultPalette =
+      TApp::instance()->getPaletteController()->getDefaultPalette(TZP_XSHLEVEL);
+  if (defaultPalette) sl->setPalette(defaultPalette->clone());
   return sl;
 }
 

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -3030,7 +3030,7 @@ public:
       }
       TXshSimpleLevel *sl = level->getSimpleLevel();
       if (!sl) {
-        DVGui::warning("Current level is not a simple level.");
+        DVGui::warning("Current level is not a drawing level.");
         return;
       }
       levelType = sl->getType();

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -3055,9 +3055,11 @@ public:
       return;
     }
 
+    TFilePath fp = ToonzFolder::getMyPalettesDir();
+    if (!TFileStatus(fp).doesExist()) TSystem::mkDir(fp);
+
     TFilePath palettePath =
-        ToonzFolder::getMyModuleDir() +
-        TFilePath(levelTypeStr.toStdString() + "_default.tpl");
+        fp + TFilePath(levelTypeStr.toStdString() + "_default.tpl");
 
     TFileStatus pfs(palettePath);
     if (pfs.doesExist()) {

--- a/toonz/sources/toonz/levelcreatepopup.cpp
+++ b/toonz/sources/toonz/levelcreatepopup.cpp
@@ -519,6 +519,11 @@ bool LevelCreatePopup::apply() {
     sl->getProperties()->setImageDpi(TPointD(dpi, dpi));
     sl->getProperties()->setImageRes(TDimension(xres, yres));
   }
+  if (lType == TZP_XSHLEVEL || lType == PLI_XSHLEVEL) {
+    TPalette *defaultPalette =
+        TApp::instance()->getPaletteController()->getDefaultPalette(lType);
+    if (defaultPalette) sl->setPalette(defaultPalette->clone());
+  }
 
   /*-- これからLevelを配置しようとしているセルが空いているかどうかのチェック
    * --*/

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -1774,6 +1774,10 @@ void MainWindow::defineActions() {
   createRightClickMenuAction(
       MI_OverwritePalette, tr("&Save Palette"), "",
       tr("Save the current style palette as a separate file."));
+  createRightClickMenuAction(MI_SaveAsDefaultPalette,
+                             tr("&Save As Default Palette"), "",
+                             tr("Save the current style palette as the default "
+                                "for new levels of the current level type."));
   createMenuFileAction(MI_LoadColorModel, tr("&Load Color Model..."), "",
                        tr("Load an image as a color guide."));
   createMenuFileAction(MI_ImportMagpieFile,

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -36,6 +36,7 @@
 #define MI_ExportLevel "MI_ExportLevel"
 #define MI_SavePaletteAs "MI_SavePaletteAs"
 #define MI_OverwritePalette "MI_OverwritePalette"
+#define MI_SaveAsDefaultPalette "MI_SaveAsDefaultPalette"
 #define MI_LoadColorModel "MI_LoadColorModel"
 #define MI_ImportMagpieFile "MI_ImportMagpieFile"
 #define MI_NewNoteLevel "MI_NewNoteLevel"

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -48,6 +48,7 @@
 #include "toonz/txshleveltypes.h"
 #include "toonz/tcamera.h"
 #include "toonz/preferences.h"
+#include "toonz/fullcolorpalette.h"
 
 #include "toonzqt/tabbar.h"
 
@@ -360,11 +361,24 @@ void TApp::updateXshLevel() {
       TXshCell cell = xsheet->getCell(frame, column);
       xl            = cell.m_level.getPointer();
 
-      // Se sono su una cella vuota successiva a celle di un certo livello
-      // prendo questo come livello corrente.
+      // If I'm on an empty cell next to cells of a certain level
+      // I take this as the current level.
       if (!xl && frame > 0) {
         TXshCell cell = xsheet->getCell(frame - 1, column);
         xl            = cell.m_level.getPointer();
+
+        // If we're on an empty cell and auto create is enabled,
+        // the current level will be the last level before us
+        if (!xl && Preferences::instance()->isAutoCreateEnabled()) {
+          int r0, r1;
+          xsheet->getCellRange(column, r0, r1);
+          for (int r = std::max(r0, std::min(r1, frame)); r >= r0; r--) {
+            TXshCell cell = xsheet->getCell(r, column);
+            if (cell.isEmpty()) continue;
+            xl = cell.m_level.getPointer();
+            break;
+          }
+        }
       }
     }
 
@@ -388,8 +402,25 @@ void TApp::updateXshLevel() {
           m_paletteController->getCurrentLevelPalette()->getStyleIndex();
       m_paletteController->getCurrentLevelPalette()->setPalette(
           xl->getPaletteLevel()->getPalette(), styleIndex);
-    } else
-      m_paletteController->getCurrentLevelPalette()->setPalette(0);
+    } else {
+      TPalette *defaultPalette = 0;
+      // Show default level type palette on empty columns when autocreate is
+      // enabled
+      if (column >= 0 && xsheet->isColumnEmpty(column) &&
+          Preferences::instance()->isAutoCreateEnabled()) {
+        int defaultLevelType = Preferences::instance()->getDefLevelType();
+        if (defaultLevelType == OVL_XSHLEVEL) {
+          ToonzScene *scene = m_currentScene->getScene();
+          defaultPalette    = FullColorPalette::instance()->getPalette(scene);
+        }
+
+        if (!defaultPalette)
+          defaultPalette =
+              m_paletteController->getDefaultPalette(defaultLevelType);
+      }
+      m_paletteController->getCurrentLevelPalette()->setPalette(defaultPalette,
+                                                                1);
+    }
   }
 }
 

--- a/toonz/sources/toonz/tapp.cpp
+++ b/toonz/sources/toonz/tapp.cpp
@@ -366,18 +366,18 @@ void TApp::updateXshLevel() {
       if (!xl && frame > 0) {
         TXshCell cell = xsheet->getCell(frame - 1, column);
         xl            = cell.m_level.getPointer();
+      }
 
-        // If we're on an empty cell and auto create is enabled,
-        // the current level will be the last level before us
-        if (!xl && Preferences::instance()->isAutoCreateEnabled()) {
-          int r0, r1;
-          xsheet->getCellRange(column, r0, r1);
-          for (int r = std::max(r0, std::min(r1, frame)); r >= r0; r--) {
-            TXshCell cell = xsheet->getCell(r, column);
-            if (cell.isEmpty()) continue;
-            xl = cell.m_level.getPointer();
-            break;
-          }
+      // If we're on an empty cell and auto create is enabled,
+      // the current level will be the last level before us
+      if (!xl && Preferences::instance()->isAutoCreateEnabled()) {
+        int r0, r1;
+        xsheet->getCellRange(column, r0, r1);
+        for (int r = std::max(r0, std::min(r1, frame)); r >= r0; r--) {
+          TXshCell cell = xsheet->getCell(r, column);
+          if (cell.isEmpty()) continue;
+          xl = cell.m_level.getPointer();
+          break;
         }
       }
     }

--- a/toonz/sources/toonz/vectorizerpopup.cpp
+++ b/toonz/sources/toonz/vectorizerpopup.cpp
@@ -36,6 +36,7 @@
 #include "toonz/sceneproperties.h"
 #include "toonz/imagemanager.h"
 #include "toonz/Naa2TlvConverter.h"
+#include "toonz/palettecontroller.h"
 
 // TnzCore includes
 #include "tsystem.h"
@@ -304,8 +305,12 @@ void Vectorizer::setLevel(const TXshSimpleLevelP &level) {
   if (sl->getType() == TZP_XSHLEVEL) {
     palette = sl->getPalette()->clone();
     replaceMyPaintBrushStyles(palette);
-  } else
-    palette = new TPalette;
+  } else {
+    TPalette *defaultPalette =
+        TApp::instance()->getPaletteController()->getDefaultPalette(
+            PLI_XSHLEVEL);
+    palette = defaultPalette ? defaultPalette->clone() : new TPalette;
+  }
 
   palette->setPaletteName(vl->getName());
   vl->setPalette(palette);

--- a/toonz/sources/toonz/xshcellviewer.cpp
+++ b/toonz/sources/toonz/xshcellviewer.cpp
@@ -57,6 +57,7 @@
 #include "toonz/txshpalettelevel.h"
 #include "toonz/doubleparamcmd.h"
 #include "toonz/preferences.h"
+#include "toonz/palettecontroller.h"
 
 // TnzBase includes
 #include "tdoublekeyframe.h"
@@ -867,6 +868,12 @@ void RenameCellField::renameCell() {
         TXshSimpleLevel *sl = xl->getSimpleLevel();
         if (levelType == TZP_XSHLEVEL || levelType == OVL_XSHLEVEL)
           sl->setFrame(fid, sl->createEmptyFrame());
+        if (levelType == TZP_XSHLEVEL || levelType == PLI_XSHLEVEL) {
+          TPalette *defaultPalette =
+              TApp::instance()->getPaletteController()->getDefaultPalette(
+                  levelType);
+          if (defaultPalette) sl->setPalette(defaultPalette->clone());
+        }
       } else
         xl = scene->createNewLevel(TZI_XSHLEVEL, levelName);
     }

--- a/toonz/sources/toonzlib/fullcolorpalette.cpp
+++ b/toonz/sources/toonzlib/fullcolorpalette.cpp
@@ -52,7 +52,7 @@ TPalette *FullColorPalette::getPalette(ToonzScene *scene) {
     // If fullcolorPalette not found, look fora default raster palette is
     // defined
     if (!TSystem::doesExistFileOrLevel(fullPath))
-      fullPath = ToonzFolder::getMyModuleDir() + "raster_default.tpl";
+      fullPath = ToonzFolder::getMyPalettesDir() + "raster_default.tpl";
   }
   if (TSystem::doesExistFileOrLevel(fullPath)) {
     TPalette *app = new TPalette();

--- a/toonz/sources/toonzlib/fullcolorpalette.cpp
+++ b/toonz/sources/toonzlib/fullcolorpalette.cpp
@@ -3,6 +3,7 @@
 #include "toonz/fullcolorpalette.h"
 #include "toonz/tscenehandle.h"
 #include "toonz/toonzscene.h"
+#include "toonz/toonzfolders.h"
 #include "tsystem.h"
 #include "tstream.h"
 #include "tpalette.h"
@@ -43,10 +44,15 @@ TPalette *FullColorPalette::getPalette(ToonzScene *scene) {
   m_palette->addRef();
   TFilePath fullPath = scene->decodeFilePath(m_fullcolorPalettePath);
   if (!TSystem::doesExistFileOrLevel(fullPath)) {
-    // Per I francesi che hanno il nome vecchio della paletta
-    // Verra' caricata la vecchia ma salvata col nome nuovo!
+    // For the French who have the old name of the headstock
+    // The old one will be loaded but saved with the new name!
     TFilePath app("+palettes\\fullcolorPalette.tpl");
     fullPath = scene->decodeFilePath(app);
+
+    // If fullcolorPalette not found, look fora default raster palette is
+    // defined
+    if (!TSystem::doesExistFileOrLevel(fullPath))
+      fullPath = ToonzFolder::getMyModuleDir() + "raster_default.tpl";
   }
   if (TSystem::doesExistFileOrLevel(fullPath)) {
     TPalette *app = new TPalette();

--- a/toonz/sources/toonzlib/palettecontroller.cpp
+++ b/toonz/sources/toonzlib/palettecontroller.cpp
@@ -20,7 +20,7 @@ TEnv::IntVar PaletteControllerAutoApplyState("PaletteControllerAutoApplyState",
                                              1);
 
 TPalette *loadDefaultPalette(QString levelType) {
-  TFilePath palettePath = ToonzFolder::getMyModuleDir() +
+  TFilePath palettePath = ToonzFolder::getMyPalettesDir() +
                           TFilePath(levelType.toStdString() + "_default.tpl");
   TFileStatus pfs(palettePath);
 

--- a/toonz/sources/toonzlib/studiopalette.cpp
+++ b/toonz/sources/toonzlib/studiopalette.cpp
@@ -218,6 +218,14 @@ TFilePath StudioPalette::getProjectPalettesRoot() {
 
 //-------------------------------------------------------------------
 
+TFilePath StudioPalette::getPersonalPalettesRoot() {
+  TFilePath folderName = ToonzFolder::getMyPalettesDir();
+  if (folderName.isEmpty()) return TFilePath();
+  return folderName;
+}
+
+//-------------------------------------------------------------------
+
 static bool loadRefImg(TPalette *palette, TFilePath dir) {
   assert(palette);
   TFilePath fp = palette->getRefImgPath();
@@ -492,6 +500,9 @@ TFilePath StudioPalette::getPalettePath(std::wstring paletteId) {
   TFilePath fp = searchPalette(m_root, paletteId);
   if (fp == TFilePath()) {
     fp = searchPalette(getProjectPalettesRoot(), paletteId);
+  }
+  if (fp == TFilePath()) {
+    fp = searchPalette(getPersonalPalettesRoot(), paletteId);
   }
   table[paletteId] = fp;
   return fp;

--- a/toonz/sources/toonzlib/toonzfolders.cpp
+++ b/toonz/sources/toonzlib/toonzfolders.cpp
@@ -185,6 +185,10 @@ TFilePath ToonzFolder::getRoomsFile(std::string fn) {
   return ToonzFolder::getRoomsFile(TFilePath(fn));
 }
 
+TFilePath ToonzFolder::getMyPalettesDir() {
+  return getMyModuleDir() + "palettes";
+}
+
 //===================================================================
 
 FolderListenerManager::FolderListenerManager() {}

--- a/toonz/sources/toonzqt/studiopaletteviewer.cpp
+++ b/toonz/sources/toonzqt/studiopaletteviewer.cpp
@@ -77,6 +77,8 @@ bool isInStudioPalette(TFilePath path) {
     return true;
   if (isInStudioPaletteFolder(path, studioPalette->getProjectPalettesRoot()))
     return true;
+  if (isInStudioPaletteFolder(path, studioPalette->getPersonalPalettesRoot()))
+    return true;
   return false;
 }
 
@@ -129,6 +131,10 @@ StudioPaletteTreeViewer::StudioPaletteTreeViewer(
   TFilePath projectPalettePath = studioPalette->getProjectPalettesRoot();
   if (TSystem::doesExistFileOrLevel(projectPalettePath))
     paletteItems.append(createRootItem(projectPalettePath));
+
+  TFilePath personalPalettePath = studioPalette->getPersonalPalettesRoot();
+  if (TSystem::doesExistFileOrLevel(personalPalettePath))
+    paletteItems.append(createRootItem(personalPalettePath));
 
   insertTopLevelItems(0, paletteItems);
 
@@ -196,7 +202,11 @@ void StudioPaletteTreeViewer::setStdPaletteHandle(
 
 QTreeWidgetItem *StudioPaletteTreeViewer::createRootItem(TFilePath path) {
   QString rootName = QString::fromStdWString(path.getWideName());
-  if (rootName != "Global Palettes") rootName = "Project Palettes";
+  if (rootName != "Global Palettes")
+    if (path == StudioPalette::instance()->getPersonalPalettesRoot())
+      rootName = "Personal Palettes";
+    else
+      rootName = "Project Palettes";
   QTreeWidgetItem *rootItem =
       new QTreeWidgetItem((QTreeWidget *)0, QStringList(rootName));
   rootItem->setIcon(0, m_folderIcon);
@@ -215,7 +225,8 @@ bool StudioPaletteTreeViewer::isRootItem(QTreeWidgetItem *item) {
 
   StudioPalette *studioPalette = StudioPalette::instance();
   if (path == studioPalette->getLevelPalettesRoot() ||
-      path == studioPalette->getProjectPalettesRoot())
+      path == studioPalette->getProjectPalettesRoot() ||
+      path == studioPalette->getPersonalPalettesRoot())
     return true;
 
   return false;
@@ -318,6 +329,10 @@ void StudioPaletteTreeViewer::refresh() {
   TFilePath projectPalettePath = studioPalette->getProjectPalettesRoot();
   if (!TSystem::doesExistFileOrLevel(projectPalettePath)) return;
   refreshItem(getItem(projectPalettePath));
+
+  TFilePath personalPalettePath = studioPalette->getPersonalPalettesRoot();
+  if (!TSystem::doesExistFileOrLevel(personalPalettePath)) return;
+  refreshItem(getItem(personalPalettePath));
 
   // refresh all expanded items
   QList<QTreeWidgetItem *> items =
@@ -898,7 +913,8 @@ void StudioPaletteTreeViewer::contextMenuEvent(QContextMenuEvent *event) {
 
     if (studioPalette->isFolder(path) &&
         studioPalette->getLevelPalettesRoot() != path &&
-        studioPalette->getProjectPalettesRoot() != path) {
+        studioPalette->getProjectPalettesRoot() != path &&
+        studioPalette->getPersonalPalettesRoot() != path) {
       menu.addSeparator();
       createMenuAction(menu, "", tr("Delete Folder"), "deleteItems()");
     } else if (studioPalette->isPalette(path)) {


### PR DESCRIPTION
This PR provides the following

1. Allows one to define personal default palettes for raster, smart raster and vector levels.

You can modify a default palette while on an empty column. Your `Preferences -> Drawing -> Default Level Type` setting will determine which default palette you are modifying.

Alternatively you can save an current level's palette as a default palette for that level type.

2. A new action to "Save As Default XXXX Palette" is available in the Palette window's tab context menu and in the options dropdown menu.

The palette will be saved as a default for the current level type you are on or your Default Level Type preference if you are on an empty column.  Example: If on a vector level, you will save as a Default Vector Palette.

Default palettes are saved under personal settings in tahomastuff/profiles/layouts/settings.xxx as

raster_default.tpl
smart_raster_default.tpl
vector_default.tpl

3. New levels will be created using a default level palette if one exists.

A level's palette will be created based on whatever is in the default palette at the time of creation.  So if you create a level, then modify the default palette, the next level will have the new changes, but older levels will not.

The default raster palette is only used when a project raster palette (+palettes\Raster_Drawing_Palette.tpl) doesn't already exist.
  
4. When Autocreation is enabled and you are on a blank frame in the xsheet/timeline, a palette will be shown

On columns with a vector, smart raster or raster level in it, shows the palette of the level just before the current frame or the palette of the 1st level in the column

On empty columns, shows a default palette based on your Preferences -> Drawing -> Default Level Type
