### PR TITLE
Add Save Scene warning popup

### DIFF
--- a/toonz/sources/include/toonz/preferencesitemids.h
+++ b/toonz/sources/include/toonz/preferencesitemids.h
@@ -197,6 +197,8 @@ enum PreferencesItemId {
   // LineTestFpsCapture,
   // guidedDrawingType,
 
+  doNotShowPopupSaveScene,
+
   PreferencesItemCount
 };
 

--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -2769,9 +2769,8 @@ public:
 
     QString question;
     question = QObject::tr(
-        "This action will not normally save any unsaved level changes, only "
-        "scene changes. Did you want to save scene only or did you really mean "
-        "to save all?");
+        "This only saves scene data, not unsaved level changes. Did you want "
+        "to save only the scene, or save all?");
     QString checkBoxLabel = QObject::tr("Do not show again.");
     QStringList buttons;
     buttons << QObject::tr("Save Scene Only") << QObject::tr("Save All");

--- a/toonz/sources/toonz/preferencespopup.cpp
+++ b/toonz/sources/toonz/preferencespopup.cpp
@@ -988,6 +988,7 @@ QString PreferencesPopup::getUIString(PreferencesItemId id) {
       // Saving
       {rasterBackgroundColor, tr("Matte color:")},
       {resetUndoOnSavingLevel, tr("Clear Undo History when Saving Levels")},
+      {doNotShowPopupSaveScene, tr("Do not show Save Scene popup warning")},
 
       // Import / Export
       {ffmpegPath, tr("FFmpeg Path:")},
@@ -1530,6 +1531,7 @@ QWidget* PreferencesPopup::createSavingPage() {
   lay->addWidget(matteColorLabel, 0, 0, 1, 3, Qt::AlignLeft);
   insertUI(rasterBackgroundColor, lay);
   insertUI(resetUndoOnSavingLevel, lay);
+  insertUI(doNotShowPopupSaveScene, lay);
 
   lay->setRowStretch(lay->rowCount(), 1);
   widget->setLayout(lay);

--- a/toonz/sources/toonzlib/preferences.cpp
+++ b/toonz/sources/toonzlib/preferences.cpp
@@ -597,6 +597,9 @@ void Preferences::definePreferenceItems() {
   define(shmall, "shmall", QMetaType::Int, -1);
   define(shmmni, "shmmni", QMetaType::Int, -1);
 #endif
+
+  define(doNotShowPopupSaveScene, "doNotShowPopupSaveScene", QMetaType::Bool,
+         false);
 }
 
 //-----------------------------------------------------------------


### PR DESCRIPTION
This PR adds a Save Scene warning popup, primarily for new users who may try to use Save Scene and not understand its impact.

![image](https://user-images.githubusercontent.com/19245851/88484340-f5147480-cf3b-11ea-9aef-bfa8d5d1f86c.png)

The popup can be disabled by checking `Do not show again` option.  It can be disabled/re-enabled in `Preferences -> Saving` as well.

Feel free to suggest a better message.