### PR TITLE
Add search command list for customize popups

### DIFF
--- a/toonz/sources/toonz/commandbarpopup.h
+++ b/toonz/sources/toonz/commandbarpopup.h
@@ -50,6 +50,12 @@ class CommandBarListTree final : public QTreeWidget {
 public:
   CommandBarListTree(QWidget* parent = 0);
 
+  void searchItems(const QString& searchWord = QString());
+
+private:
+  void displayAll(QTreeWidgetItem* item);
+  void hideAll(QTreeWidgetItem* item);
+
 protected:
   void mousePressEvent(QMouseEvent*) override;
 };
@@ -68,6 +74,7 @@ public:
   CommandBarPopup(bool isXsheetToolbar = false);
 protected slots:
   void onOkPressed();
+  void onSearchTextChanged(const QString& text);
 };
 
 #endif


### PR DESCRIPTION
This PR closes #96 

Adds a Search box above the Toolbar Items list in Customize Command Bar (shown) and Customize XSheet Toolbar popups.

![image](https://user-images.githubusercontent.com/19245851/88461460-a7333a00-ce71-11ea-9853-850daffbaa8a.png)

I chose to put the search above the list in keeping with other tree filters (shortcut, insert fx).  Can move upon request.