### PR TITLE
Make short play work universally

### DIFF
--- a/toonz/sources/include/toonzqt/flipconsole.h
+++ b/toonz/sources/include/toonzqt/flipconsole.h
@@ -286,6 +286,7 @@ public:
   }
   UINT getCustomizeMask() { return m_customizeMask; }
   void setCustomizemask(UINT mask);
+  void setStopAt(int frame);
 
   // the main (currently the only) use for current flipconsole and setActive is
   // to
@@ -362,6 +363,7 @@ private:
   std::vector<int> m_gadgetsMask;
   int m_from, m_to, m_step;
   int m_currentFrame, m_framesCount;
+  int m_stopAt = -1;
   ImagePainter::VisualSettings m_settings;
 
   bool m_isPlay;

--- a/toonz/sources/stopmotion/stopmotion.cpp
+++ b/toonz/sources/stopmotion/stopmotion.cpp
@@ -417,7 +417,7 @@ void StopMotion::onPlaybackChanged() {
 
   int frame     = TApp::instance()->getCurrentFrame()->getFrame();
   int lastFrame = TApp::instance()->getCurrentFrame()->getMaxFrameIndex();
-  if (frame == 0 || frame == lastFrame) {
+  if (m_xSheetFrameNumber - 1 == frame + 1) {
     TApp::instance()->getCurrentFrame()->setFrame(m_xSheetFrameNumber - 1);
   }
 }

--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -16,10 +16,6 @@
 #include "toonz/tframehandle.h"
 #include "toonz/tcolumnhandle.h"
 #include "toonz/preferences.h"
-#include "toonz/toonzscene.h"
-#include "toonz/tscenehandle.h"
-#include "toonz/sceneproperties.h"
-#include "toutputproperties.h"
 
 #include <QApplication>
 
@@ -147,20 +143,6 @@ public:
         TApp::instance()->getCurrentXsheet()->getXsheet()->getFrameCount();
 
     int stopFrame = std::min(currentFrame, maxFrame);
-
-    int r0, r1, step;
-    TApp::instance()
-        ->getCurrentScene()
-        ->getScene()
-        ->getProperties()
-        ->getPreviewProperties()
-        ->getRange(r0, r1, step);
-    if (stopFrame < r0) {
-      stopFrame = r0 + shortPlayFrameCount;
-    }
-    if (r1 > 0 && stopFrame > r1) {
-      stopFrame = r1;
-    }
 
     int startFrame = std::max(0, stopFrame - shortPlayFrameCount);
 

--- a/toonz/sources/toonz/vcrcommand.cpp
+++ b/toonz/sources/toonz/vcrcommand.cpp
@@ -137,13 +137,18 @@ public:
   ShortPlayCommand() : MenuItemHandler(MI_ShortPlay) {}
 
   void execute() override {
-    int row = TApp::instance()->getCurrentFrame()->getFrame();
+    int row                 = TApp::instance()->getCurrentFrame()->getFrame();
     int shortPlayFrameCount = Preferences::instance()->getShortPlayFrameCount();
-    int count =
+    int maxFrame =
         TApp::instance()->getCurrentXsheet()->getXsheet()->getFrameCount();
-    int newFrame = std::max(
-      0, count - shortPlayFrameCount);
+
+    int count    = std::min(row, maxFrame);
+    int newFrame = std::max(0, count - shortPlayFrameCount);
+
     TApp::instance()->getCurrentFrame()->setFrame(newFrame);
+    FlipConsole *console = FlipConsole::getCurrent();
+    console->setStopAt(count + 1);
+
     CommandManager::instance()->execute(MI_Play);
   }
 };

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -831,7 +831,8 @@ void FlipConsole::setFpsFieldColors() {
 
 void FlipConsole::playNextFrame() {
   int from = m_from, to = m_to;
-  if (m_markerFrom <= m_markerTo) from = m_markerFrom, to = m_markerTo;
+  if (m_markerFrom <= m_markerTo && m_stopAt == -1)
+    from = m_markerFrom, to = m_markerTo;
 
   if (m_framesCount == 0 ||
       (m_isPlay && m_currentFrame == (m_reverse ? from : to))) {
@@ -1604,9 +1605,12 @@ void FlipConsole::doButtonPressed(UINT button) {
 
   int from = m_from, to = m_to;
   // When the level editing mode, ignore the preview frame range marker
-  if (m_markerFrom <= m_markerTo && m_frameHandle &&
-      m_frameHandle->isEditingScene())
-    from = m_markerFrom, to = m_markerTo;
+  if ((m_markerFrom <= m_markerTo && m_frameHandle &&
+       m_frameHandle->isEditingScene()) &&
+      m_stopAt == -1) {
+    from = m_markerFrom;
+    to   = m_markerTo;
+  }
 
   bool linked = m_areLinked && m_isLinkable;
 

--- a/toonz/sources/toonzqt/flipconsole.cpp
+++ b/toonz/sources/toonzqt/flipconsole.cpp
@@ -805,6 +805,10 @@ void FlipConsole::onNextFrame(int fps) {
     else
       m_fpsField->setLineEditBackgroundColor(Qt::red);
   }
+  if (m_stopAt > 0 && m_currentFrame >= m_stopAt) {
+    doButtonPressed(ePause);
+    m_stopAt = -1;
+  }
 }
 
 //----------------------------------------------------------------------------
@@ -1525,12 +1529,14 @@ void FlipConsole::onButtonPressed(int button) {
           playingConsole->setChecked(eLoop, false);
           playingConsole->setChecked(ePause, true);
           stoppedOther = true;
+          m_stopAt     = -1;
         }
       }
       if (stoppedOther) {
         setChecked(ePlay, false);
         setChecked(eLoop, false);
         setChecked(ePause, true);
+        m_stopAt = -1;
         return;
       }
     }
@@ -1676,13 +1682,14 @@ void FlipConsole::doButtonPressed(UINT button) {
           playingConsole->setChecked(ePause, true);
         }
       }
+      m_stopAt = -1;
       return;
     }
 
     m_isLinkedPlaying = false;
 
     if (m_playbackExecutor.isRunning()) m_playbackExecutor.abort();
-
+    m_stopAt       = -1;
     m_isPlay       = false;
     m_blanksToDraw = 0;
 
@@ -1811,6 +1818,10 @@ void FlipConsole::doButtonPressed(UINT button) {
   updateCurrentTime();
   m_consoleOwner->onDrawFrame(m_currentFrame, m_settings);
 }
+
+//--------------------------------------------------------------------
+
+void FlipConsole::setStopAt(int frame) { m_stopAt = frame; }
 
 //--------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #9 

Allows short play to work even in the middle of the timeline/xsheet.  No longer only works from the end.

@manongjohn Do you have a couple minutes to look at this?