### PR TITLE
Fix saving default palette

### DIFF
--- a/toonz/sources/toonz/iocommand.cpp
+++ b/toonz/sources/toonz/iocommand.cpp
@@ -3100,6 +3100,13 @@ public:
       if (ret == 2 || ret == 0) return;
     }
 
+    if (!palette->isDefaultPalette()) {
+      palette = palette->clone();
+      palette->setPaletteName(L"Default " + displayStr.toStdWString() +
+                              L" Palette");
+      palette->setIsDefaultPalette(true);
+    }
+
     StudioPalette::instance()->save(palettePath, palette);
     TApp::instance()->getPaletteController()->setDefaultPalette(levelType,
                                                                 palette);


### PR DESCRIPTION
This PR fixes #106 

Issue: When saving a level palette as a default palette, it was storing the level palette as the default palette.  When switching scenes, the level palette would be destroyed, leaving a non-existing palette as the default which resulted in a crash when accessing it.

Resolution: When saving a level palette as a default palette, a clone of the level palette is stored as the default palette instead so it would not be destructed when switching levels.