### PR TITLE
Fix undo guided strokes clearing frames

### DIFF
--- a/toonz/sources/tnztools/tool.cpp
+++ b/toonz/sources/tnztools/tool.cpp
@@ -1303,6 +1303,7 @@ void TTool::tweenSelectedGuideStrokes() {
   if (vbTool) {
     m_isFrameCreated = false;
     m_isLevelCreated = false;
+    vbTool->touchImage();
     vbTool->setViewer(m_viewer);
     vbTool->doFrameRangeStrokes(
         bFid, bStroke, fFid, fStroke,
@@ -1404,6 +1405,7 @@ void TTool::tweenGuideStrokeToSelected() {
   if (vbTool) {
     m_isFrameCreated = false;
     m_isLevelCreated = false;
+    vbTool->touchImage();
     vbTool->setViewer(m_viewer);
     TUndoManager::manager()->beginBlock();
     if (bStroke)

--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -1165,6 +1165,7 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
 
       bool frameCreated = m_isFrameCreated;
       m_isFrameCreated  = false;
+      touchImage();
       resultBack        = doFrameRangeStrokes(
           oFid, fStroke, cFid, cStroke,
           Preferences::instance()->getGuidedInterpolation(), breakAngles,
@@ -1199,6 +1200,7 @@ bool ToonzVectorBrushTool::doGuidedAutoInbetween(
 
       bool frameCreated = m_isFrameCreated;
       m_isFrameCreated  = false;
+      touchImage();
       resultFront       = doFrameRangeStrokes(
           cFid, cStroke, oFid, fStroke,
           Preferences::instance()->getGuidedInterpolation(), breakAngles,


### PR DESCRIPTION
This PR fixes #108 

Issue: When auto inbetweening occurs and the strokes are drawn and added to undo stack, information from the tool's previous action, creating and renumbering frames, is also stored.  As a result, when undoing the auto inbetween, OT thinks it has to also undo the create/renumber action.

Fix: Reset tool's internal information back to baseline prior to performing the auto inbetweening. 