### PR TITLE
Fix no icon for newly created blank frames

### DIFF
--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1248,6 +1248,8 @@ public:
   void redo() const override {
     insertLevelAndFrameIfNeeded();
 
+    IconGenerator::instance()->invalidate(m_level.getPointer(), m_frameId);
+
     TApp::instance()->getCurrentXsheet()->notifyXsheetChanged();
     notifyImageChanged();
   }
@@ -2428,6 +2430,8 @@ void TCellSelection::createBlankDrawing(int row, int col, bool multiple) {
   CreateBlankDrawingUndo *undo = new CreateBlankDrawingUndo(
       sl, frame, toolHandle->getTool()->m_isLevelCreated, palette);
   TUndoManager::manager()->add(undo);
+
+  IconGenerator::instance()->invalidate(sl, frame);
 
   // Reset back to what these were
   if (!isAutoCreateEnabled)


### PR DESCRIPTION
This PR fixes an issue where newly created blank frames create a `no icon` frame in the level strip.  If you selected multiple cells and used create blank frame, the icons would be larger than expected, creating a mess in the level strip.

Issue: Icon manager not triggered to refresh the icons after the blank frame was created.

Fix: Invalidate level frame upon initial creation and during redo so the icon manager knows to refresh the icon in the level strip.