### PR TITLE
Add Raw Image Support to Stop Motion

### DIFF
--- a/toonz/sources/stopmotion/canon.h
+++ b/toonz/sources/stopmotion/canon.h
@@ -102,6 +102,7 @@ public:
   int m_liveViewExposureOffset      = 0;
   QString m_realShutterSpeed;
   QString m_displayedShutterSpeed;
+  QString m_imageQuality;
 
 // Canon Commands
 #ifdef WITH_CANON

--- a/toonz/sources/stopmotion/stopmotion.h
+++ b/toonz/sources/stopmotion/stopmotion.h
@@ -90,7 +90,7 @@ public:
   bool m_isTimeLapse       = false;
   int m_reviewTime         = 2;
   bool m_isTestShot        = false;
-  QString m_tempFile;
+  QString m_tempFile, m_tempRaw;
   TXshSimpleLevel* m_sl;
 
   // timers


### PR DESCRIPTION
This allows raw format images types to be selected for stop motion.  OpenToonz doesn't actually handle raw images, so after capture, the raw image is downloaded to the computer.  The embedded jpg is then extracted from the raw image and shown in OT.

The raw image sequence would then need to be brought in to a program like after effects or resolved to actually be used.  This behavior is similar to other frame grabbers such as DragonFrame.