### PR TITLE
Display Fx Icon as timeline/xsheet thumbnail

### DIFF
--- a/toonz/sources/include/toonz/txshzeraryfxcolumn.h
+++ b/toonz/sources/include/toonz/txshzeraryfxcolumn.h
@@ -37,7 +37,12 @@ class DVAPI TXshZeraryFxColumn final : public TXshCellColumn {
   TZeraryColumnFx *m_zeraryColumnFx;
   TXshZeraryFxLevel *m_zeraryFxLevel;
 
+  bool m_iconVisible;
+
 public:
+  bool isIconVisible() { return m_iconVisible; }
+  void setIconVisible(bool visible) { m_iconVisible = visible; }
+
   /*!
 Constructs a TXshZeraryFxColumn with default value.
 */

--- a/toonz/sources/include/toonzqt/fxiconmanager.h
+++ b/toonz/sources/include/toonzqt/fxiconmanager.h
@@ -9,6 +9,18 @@
 
 #include "tcommon.h"
 
+#include <QPixmap>
+
+#undef DVAPI
+#undef DVVAR
+#ifdef TOONZQT_EXPORTS
+#define DVAPI DV_EXPORT_API
+#define DVVAR DV_EXPORT_VAR
+#else
+#define DVAPI DV_IMPORT_API
+#define DVVAR DV_IMPORT_VAR
+#endif
+
 class QPixmap;
 
 namespace {
@@ -136,13 +148,16 @@ const struct {
     {0, 0}};
 };
 
-class FxIconPixmapManager {  // singleton
-
-  std::map<std::string, QPixmap> m_pms;
-
-  FxIconPixmapManager();
+class DVAPI FxIconPixmapManager final : public QObject {  // singleton
+  Q_OBJECT
 
 public:
+  std::map<std::string, QPixmap> m_pms;
+
+public:
+  FxIconPixmapManager();
+  ~FxIconPixmapManager();
+
   static FxIconPixmapManager *instance();
 
   const QPixmap &getFxIconPm(std::string type);

--- a/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
+++ b/toonz/sources/toonzlib/txshzeraryfxcolumn.cpp
@@ -15,7 +15,8 @@
 
 TXshZeraryFxColumn::TXshZeraryFxColumn(int frameCount)
     : m_zeraryColumnFx(new TZeraryColumnFx())
-    , m_zeraryFxLevel(new TXshZeraryFxLevel()) {
+    , m_zeraryFxLevel(new TXshZeraryFxLevel())
+    , m_iconVisible(false) {
   m_zeraryColumnFx->addRef();
   m_zeraryColumnFx->setColumn(this);
   m_zeraryFxLevel->addRef();

--- a/toonz/sources/toonzqt/CMakeLists.txt
+++ b/toonz/sources/toonzqt/CMakeLists.txt
@@ -27,6 +27,7 @@ set(MOC_HEADERS
     ../include/toonzqt/functiontreeviewer.h
     ../include/toonzqt/functionviewer.h
     ../include/toonzqt/fxhistogramrender.h
+    ../include/toonzqt/fxiconmanager.h
     ../include/toonzqt/fxschematicnode.h
     ../include/toonzqt/fxschematicscene.h
     ../include/toonzqt/fxselection.h
@@ -87,7 +88,6 @@ set(HEADERS
     ../include/toonzqt/dvmimedata.h
     ../include/toonzqt/flipconsoleowner.h
     ../include/toonzqt/freelayout.h
-    ../include/toonzqt/fxiconmanager.h
     ../include/toonzqt/fxtypes.h
     ../include/toonzqt/glwidget_for_highdpi.h
     ../include/toonzqt/lutcalibrator.h

--- a/toonz/sources/toonzqt/fxiconmanager.cpp
+++ b/toonz/sources/toonzqt/fxiconmanager.cpp
@@ -4,6 +4,8 @@
 
 FxIconPixmapManager::FxIconPixmapManager() {}
 
+FxIconPixmapManager::~FxIconPixmapManager() {}
+
 FxIconPixmapManager *FxIconPixmapManager::instance() {
   static FxIconPixmapManager _instance;
   return &_instance;


### PR DESCRIPTION
With the recent changes to the UI, there was a request to replace the text displayed in thumbnails for Fx columns (Zerary Fx) that appear in the xsheet/timeline with some image.  If was agreed to take the icon used in the Fx Schematic node view and make that the thumbnail for these columns.

![image](https://user-images.githubusercontent.com/19245851/91759588-e73bba00-eb9f-11ea-8a48-50cc4b118bbf.png)

The current icons are PNG will look a little pixelated since they are smaller than the thumbnail size. It's not too bad for timeline.  There is an endeavor to replace them with SVG icons, but will most likely be done separately.
