### PR TITLE
Tahoma build scripts

### DIFF
--- a/ci-scripts/linux/tahoma-build.sh
+++ b/ci-scripts/linux/tahoma-build.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+pushd thirdparty/tiff-4.0.3
+CFLAGS="-fPIC" CXXFLAGS="-fPIC" ./configure --disable-jbig && make
+popd
+
+cd toonz
+
+mkdir build
+cd build
+
+source /opt/qt59/bin/qt59-env.sh
+
+cmake ../sources \
+    -DWITH_SYSTEM_SUPERLU:BOOL=OFF
+
+make -j7

--- a/ci-scripts/linux/tahoma-buildffmpeg.sh
+++ b/ci-scripts/linux/tahoma-buildffmpeg.sh
@@ -1,0 +1,65 @@
+cd thirdparty
+
+echo ">>> Cloning openH254"
+git clone https://github.com/cisco/openh264.git openh264
+
+cd openh264
+echo "*" >| .gitignore
+
+echo ">>> Making openh264"
+make
+
+echo ">>> Installing openh264"
+sudo make install
+
+cd ..
+
+echo ">>> Cloning ffmpeg"
+git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
+
+cd ffmpeg
+echo "*" >| .gitignore
+
+echo ">>> Configuring to build ffmpeg"
+export PKG_CONFIG_PATH=/usr/local/lib/pkgconfig
+
+./configure  --prefix=/usr/local \
+      --toolchain=hardened \
+      --pkg-config-flags="--static" \
+      --extra-cflags="-I/usr/local/include" \
+      --extra-ldflags="-L/usr/local/lib" \
+      --enable-pthreads \
+      --enable-version3 \
+      --enable-avresample \
+      --enable-gnutls \
+      --enable-libbluray \
+      --enable-libmp3lame \
+      --enable-libopus \
+      --enable-libsnappy \
+      --enable-libtheora \
+      --enable-libvorbis \
+      --enable-libvpx \
+      --enable-libwebp \
+      --enable-libxml2 \
+      --enable-lzma \
+      --enable-libfreetype \
+      --enable-libass \
+      --enable-libopencore-amrnb \
+      --enable-libopencore-amrwb \
+      --enable-libopenjpeg \
+      --enable-libspeex \
+      --enable-libsoxr \
+      --enable-libopenh264 \
+      --enable-shared \
+      --disable-static \
+      --disable-libjack \
+      --disable-indev=jack
+
+echo ">>> Building ffmpeg"
+make
+
+echo ">>> Installing ffmpeg"
+sudo make install
+
+sudo ldconfig
+

--- a/ci-scripts/linux/tahoma-buildopencv.sh
+++ b/ci-scripts/linux/tahoma-buildopencv.sh
@@ -1,0 +1,51 @@
+cd thirdparty
+
+echo ">>> Cloning opencv"
+git clone https://github.com/opencv/opencv.git
+
+cd opencv
+echo "*" >| .gitignore
+
+mkdir build
+cd build
+
+echo ">>> Cmaking openv"
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_JASPER=OFF \
+      -DBUILD_JPEG=OFF \
+      -DBUILD_OPENEXR=OFF \
+      -DBUILD_PERF_TESTS=OFF \
+      -DBUILD_PNG=OFF \
+      -DBUILD_PROTOBUF=OFF \
+      -DBUILD_TESTS=OFF \
+      -DBUILD_TIFF=OFF \
+      -DBUILD_WEBP=OFF \
+      -DBUILD_ZLIB=OFF \
+      -DBUILD_opencv_hdf=OFF \
+      -DBUILD_opencv_java=OFF \
+      -DBUILD_opencv_text=ON \
+      -DOPENCV_ENABLE_NONFREE=ON \
+      -DOPENCV_GENERATE_PKGCONFIG=ON \
+      -DPROTOBUF_UPDATE_FILES=ON \
+      -DWITH_1394=OFF \
+      -DWITH_CUDA=OFF \
+      -DWITH_EIGEN=ON \
+      -DWITH_FFMPEG=ON \
+      -DWITH_GPHOTO2=OFF \
+      -DWITH_GSTREAMER=ON \
+      -DWITH_JASPER=OFF \
+      -DWITH_OPENEXR=ON \
+      -DWITH_OPENGL=OFF \
+      -DWITH_QT=OFF \
+      -DWITH_TBB=ON \
+      -DWITH_VTK=ON \
+      -DBUILD_opencv_python2=OFF \
+      -DBUILD_opencv_python3=ON \
+      -DCMAKE_INSTALL_NAME_DIR=/usr/local/lib \
+      ..
+
+echo ">>> Building opencv"
+make
+
+echo ">>> Installing opencv"
+sudo make install

--- a/ci-scripts/linux/tahoma-buildpkg.sh
+++ b/ci-scripts/linux/tahoma-buildpkg.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+source /opt/qt59/bin/qt59-env.sh
+
+echo ">>> Temporary install of Tahoma"
+export BUILDDIR=$(pwd)/toonz/build
+cd $BUILDDIR
+sudo make install
+
+sudo ldconfig
+
+echo ">>> Creating appDir"
+rm -rf appdir
+mkdir -p appdir/usr
+
+echo ">>> Copy and configure Tahoma installation in appDir"
+cp -r /opt/tahoma/* appdir/usr
+cp appdir/usr/share/applications/*.desktop appdir
+cp appdir/usr/share/icons/hicolor/*/apps/*.png appdir
+mv appdir/usr/lib/tahoma/* appdir/usr/lib
+rmdir appdir/usr/lib/tahoma
+
+echo ">>> Creating Tahoma directory"
+rm -rf Tahoma
+mkdir Tahoma
+
+echo ">>> Copying stuff to Tahoma/tahomastuff"
+
+mv appdir/usr/share/tahoma/stuff Tahoma/tahomastuff
+chmod -R 777 Tahoma/tahomastuff
+rmdir appdir/usr/share/tahoma
+
+if [ -d ../../thirdparty/ffmpeg/bin ]
+then
+   echo ">>> Copying FFmpeg to Tahoma/ffmpeg"
+   cp -R ../../thirdparty/ffmpeg/bin Tahoma/ffmpeg
+fi
+
+echo ">>> Creating Tahoma/Tahoma.AppImage"
+
+if [ ! -f linuxdeployqt*.AppImage ]
+then
+   wget -c "https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage"
+   chmod a+x linuxdeployqt*.AppImage
+fi
+
+export LD_LIBRARY_PATH=appdir/usr/lib/tahoma
+./linuxdeployqt*.AppImage appdir/usr/bin/Tahoma -bundle-non-qt-libs -verbose=0 -always-overwrite \
+   -executable=appdir/usr/bin/lzocompress \
+   -executable=appdir/usr/bin/lzodecompress \
+   -executable=appdir/usr/bin/tcleanup \
+   -executable=appdir/usr/bin/tcomposer \
+   -executable=appdir/usr/bin/tconverter \
+   -executable=appdir/usr/bin/tfarmcontroller \
+   -executable=appdir/usr/bin/tfarmserver 
+./linuxdeployqt*.AppImage appdir/usr/bin/Tahoma -appimage
+
+mv Tahoma*.AppImage Tahoma/Tahoma.AppImage
+
+echo ">>> Creating Tahoma Linux package"
+
+tar zcf Tahoma-linux.tar.gz Tahoma

--- a/ci-scripts/linux/tahoma-install.sh
+++ b/ci-scripts/linux/tahoma-install.sh
@@ -1,0 +1,45 @@
+sudo add-apt-repository --yes ppa:beineri/opt-qt597-xenial
+sudo add-apt-repository --yes ppa:achadwick/mypaint-testing
+sudo apt-get update
+sudo apt-get install -y cmake liblzo2-dev liblz4-dev libfreetype6-dev libpng-dev libegl1-mesa-dev libgles2-mesa-dev libglew-dev freeglut3-dev qt59script libsuperlu-dev qt59svg qt59tools qt59multimedia wget libusb-1.0-0-dev libboost-all-dev liblzma-dev libjson-c-dev libmypaint-dev libjpeg-turbo8-dev libglib2.0-dev qt59serialport
+sudo apt-get install -y nasm yasm libgnutls-dev libass-dev libbluray-dev libmp3lame-dev libopus-dev libsnappy-dev libtheora-dev libvorbis-dev libvpx-dev libwebp-dev libxml2-dev libfontconfig1-dev libfreetype6-dev libopencore-amrnb-dev libopencore-amrwb-dev libopenjpeg-dev libspeex-dev libsoxr-dev libopenjp2-7-dev
+sudo apt-get install -y python3-pip
+
+pip3 install --upgrade pip
+pip3 install numpy
+
+# Leave repo directory for this step
+cd ..
+
+# someone forgot to include liblz4.pc with the package, use the version from xenial, as it only depends on libc
+if [ ! -f liblz4.deb ]
+then
+   wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-1_0.0~r131-2ubuntu2_amd64.deb -O liblz4.deb
+fi
+
+if [ ! -f liblz4-dev.db ]
+then
+   wget http://mirrors.kernel.org/ubuntu/pool/main/l/lz4/liblz4-dev_0.0~r131-2ubuntu2_amd64.deb -O liblz4-dev.deb
+fi
+
+sudo dpkg -i liblz4.deb liblz4-dev.deb
+
+# Remove this as the version that is there is old and causes issues compiling opencv
+sudo apt-get remove libprotobuf-dev
+
+# Need protoc3 for some compiles.  don't use the apt-get version as it's too old.
+
+if [ ! -d protoc3 ]
+then
+   wget https://github.com/google/protobuf/releases/download/v3.6.1/protoc-3.6.1-linux-x86_64.zip
+   # Unzip
+   unzip protoc-3.6.1-linux-x86_64.zip -d protoc3
+fi
+
+# Move protoc to /usr/local/bin/
+sudo cp -pr protoc3/bin/* /usr/local/bin/
+
+# Move protoc3/include to /usr/local/include/
+sudo cp -pr protoc3/include/* /usr/local/include/
+
+sudo ldconfig

--- a/ci-scripts/osx/tahoma-build.sh
+++ b/ci-scripts/osx/tahoma-build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+pushd thirdparty/tiff-4.0.3
+./configure --disable-lzma --without-x && make
+popd
+
+cd toonz
+
+mkdir build
+cd build
+
+QTVERSION=`ls /usr/local/Cellar/qt`
+echo "QT Version detected: $QTVERSION"
+
+if [ -d ../../thirdparty/canon/Header ]
+then
+   export CANON_FLAG=-DWITH_CANON=ON
+fi
+
+export PKG_CONFIG_PATH="$PKG_CONFIG_PATH:/usr/local/opt/jpeg-turbo/lib/pkgconfig"
+cmake ../sources  $CANON_FLAG \
+      -DQT_PATH=/usr/local/opt/qt/lib/ \
+      -DTIFF_INCLUDE_DIR=../../thirdparty/tiff-4.0.3/libtiff/ \
+      -DSUPERLU_INCLUDE_DIR=../../thirdparty/superlu/SuperLU_4.1/include/
+
+make -j7 # runs 7 jobs in parallel

--- a/ci-scripts/osx/tahoma-buildffmpeg.sh
+++ b/ci-scripts/osx/tahoma-buildffmpeg.sh
@@ -1,0 +1,49 @@
+cd thirdparty
+
+echo ">>> Cloning ffmpeg"
+git clone https://git.ffmpeg.org/ffmpeg.git ffmpeg
+
+cd ffmpeg
+echo "*" >| .gitignore
+
+echo ">>> Configuring to build ffmpeg"
+export PKG_CONFIG_PATH=/usr/local/lib/pkconfig
+
+./configure  --prefix=/usr/local \
+      --enable-shared \
+      --enable-pthreads \
+      --enable-version3 \
+      --enable-avresample \
+      --enable-gnutls \
+      --enable-libaom \
+      --enable-libbluray \
+      --enable-libdav1d \
+      --enable-libmp3lame \
+      --enable-libopus \
+      --enable-librav1e \
+      --enable-libsnappy \
+      --enable-libtesseract \
+      --enable-libtheora \
+      --enable-libvorbis \
+      --enable-libvpx \
+      --enable-libwebp \
+      --enable-libxml2 \
+      --enable-lzma \
+      --enable-libfontconfig \
+      --enable-libfreetype \
+      --enable-libass \
+      --enable-libopencore-amrnb \
+      --enable-libopencore-amrwb \
+      --enable-libopenjpeg \
+      --enable-libspeex \
+      --enable-libsoxr \
+      --enable-videotoolbox \
+      --enable-libopenh264 \
+      --disable-libjack \
+      --disable-indev=jack
+
+echo ">>> Building ffmpeg"
+make -j7 # runs 7 jobs in parallel
+
+echo ">>> Installing ffmpeg"
+make install

--- a/ci-scripts/osx/tahoma-buildopencv.sh
+++ b/ci-scripts/osx/tahoma-buildopencv.sh
@@ -1,0 +1,52 @@
+cd thirdparty
+
+echo ">>> Cloning opencv"
+git clone https://github.com/opencv/opencv.git
+
+cd opencv
+echo "*" >| .gitignore
+
+mkdir build
+cd build
+
+echo ">>> Cmaking openv"
+cmake -DCMAKE_BUILD_TYPE=Release \
+      -DBUILD_JASPER=OFF \
+      -DBUILD_JPEG=OFF \
+      -DBUILD_OPENEXR=OFF \
+      -DBUILD_PERF_TESTS=OFF \
+      -DBUILD_PNG=OFF \
+      -DBUILD_PROTOBUF=OFF \
+      -DBUILD_TESTS=OFF \
+      -DBUILD_TIFF=OFF \
+      -DBUILD_WEBP=OFF \
+      -DBUILD_ZLIB=OFF \
+      -DBUILD_opencv_hdf=OFF \
+      -DBUILD_opencv_java=OFF \
+      -DBUILD_opencv_text=ON \
+      -DOPENCV_ENABLE_NONFREE=ON \
+      -DOPENCV_GENERATE_PKGCONFIG=ON \
+      -DPROTOBUF_UPDATE_FILES=ON \
+      -DWITH_1394=OFF \
+      -DWITH_CUDA=OFF \
+      -DWITH_EIGEN=ON \
+      -DWITH_FFMPEG=ON \
+      -DWITH_GPHOTO2=OFF \
+      -DWITH_GSTREAMER=OFF \
+      -DWITH_JASPER=OFF \
+      -DWITH_OPENEXR=ON \
+      -DWITH_OPENGL=OFF \
+      -DWITH_QT=OFF \
+      -DWITH_TBB=ON \
+      -DWITH_VTK=ON \
+      -DBUILD_opencv_python2=OFF \
+      -DBUILD_opencv_python3=ON \
+      -DCMAKE_MACOS_RPATH=FALSE \
+      -DCMAKE_INSTALL_NAME_DIR=/usr/local/lib \
+      ..
+
+echo ">>> Building opencv"
+make -j7 # runs 7 jobs in parallel
+
+echo ">>> Installing opencv"
+make install

--- a/ci-scripts/osx/tahoma-buildpkg.sh
+++ b/ci-scripts/osx/tahoma-buildpkg.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+export QTDIR=/usr/local/opt/qt
+export TOONZDIR=toonz/build/toonz
+
+# If found, use Xcode Release build
+if [ -d $TOONZDIR/Release ]
+then
+   export TOONZDIR=$TOONZDIR/Release
+fi
+
+echo ">>> Copying stuff to $TOONZDIR/Tahoma.app/tahomastuff"
+cp -R stuff $TOONZDIR/Tahoma.app/tahomastuff
+
+if [ -d thirdparty/ffmpeg/bin ]
+then
+   echo ">>> Copying FFmpeg to $TOONZDIR/Tahoma.app/ffmpeg"
+   cp -R thirdparty/ffmpeg/bin $TOONZDIR/Tahoma.app/ffmpeg
+fi
+
+if [ -d thirdparty/canon/Framework ]
+then
+   echo ">>> Copying canon framework to $TOONZDIR/Tahoma.app/Contents/Frameworks/EDSDK.Framework"
+   cp -R thirdparty/canon/Framework $TOONZDIR/Tahoma.app/Contents/Frameworks
+fi
+
+echo ">>> Configuring Tahoma.app for deployment"
+
+$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma.app -verbose=0 -always-overwrite \
+   -executable=$TOONZDIR/Tahoma.app/Contents/MacOS/lzocompress \
+   -executable=$TOONZDIR/Tahoma.app/Contents/MacOS/lzodecompress \
+   -executable=$TOONZDIR/Tahoma.app/Contents/MacOS/tcleanup \
+   -executable=$TOONZDIR/Tahoma.app/Contents/MacOS/tcomposer \
+   -executable=$TOONZDIR/Tahoma.app/Contents/MacOS/tconverter \
+   -executable=$TOONZDIR/Tahoma.app/Contents/MacOS/tfarmcontroller \
+   -executable=$TOONZDIR/Tahoma.app/Contents/MacOS/tfarmserver 
+
+echo ">>> Correcting library paths"
+for X in `find $TOONZDIR/Tahoma.app/Contents -type f -name *.dylib -exec otool -l {} \; | grep -e "^toonz" -e"name \/usr\/local" | sed -e"s/://" -e"s/ (.*$//" -e"s/^ *name //"`
+do
+   Z=`echo $X | cut -c 1-1`
+   if [ "$Z" != "/" ]
+   then
+      LIBFILE=$X
+   else
+      Y=`basename $X`
+      W=`basename $LIBFILE`
+      if [ -f $TOONZDIR/Tahoma.app/Contents/Frameworks/$Y -a "$Y" != "$W" ]
+      then
+         echo "Fixing $X in $LIBFILE"
+         install_name_tool -change $X @executable_path/../Frameworks/$Y $LIBFILE
+      fi
+   fi
+done
+   
+echo ">>> Creating Tahoma-osx.dmg"
+
+$QTDIR/bin/macdeployqt $TOONZDIR/Tahoma.app -dmg -verbose=0
+
+mv $TOONZDIR/Tahoma.dmg $TOONZDIR/../Tahoma-osx.dmg

--- a/ci-scripts/osx/tahoma-install.sh
+++ b/ci-scripts/osx/tahoma-install.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+brew update
+# from Homebrew 1.6.0 the old formula for obtaining Qt5.9.2 becomes invalid.
+# so we start to use the latest version of Qt. (#1910)
+brew install qt clang-format glew lz4 lzo libusb libmypaint jpeg-turbo nasm yasm aom dav1d fontconfig freetype gnutls lame libass libbluray libsoxr libvorbis libvpx opencore-amr openh264 openjpeg opus rav1e sdl2 snappy speex tesseract theora webp xvid xz
+brew tap tcr/tcr
+# delete older qt versions and make sure to have only the latest
+brew cleanup qt
+# temp workaround to brew installed glew cmake info overriding glew lib detection
+# which causes compiling issues later
+if [ -L /usr/local/lib/cmake/glew ]
+then
+   echo "Symbolic link '/usr/local/lib/cmake/glew' detected. Removing to avoid glew lib detection issue!"
+   ls -l /usr/local/lib/cmake/glew
+   rm /usr/local/lib/cmake/glew
+fi

--- a/toonz/sources/CMakeLists.txt
+++ b/toonz/sources/CMakeLists.txt
@@ -284,12 +284,11 @@ if(BUILD_ENV_MSVC)
         PATHS "C:/OpenCV/opencv/build" "C:/opencv/build" "C:/Tools/opencv/build"
     )
 elseif(BUILD_ENV_UNIXLIKE)
-    find_package(OpenCV 3.2 REQUIRED)
+    find_package(OpenCV REQUIRED)
 else()
-    find_package(OpenCV 4.1 REQUIRED
-        # PATHS "/Users/turtletooth/opencv_build/"
-    )
+    find_package(OpenCV 4.1 REQUIRED)
 endif()
+
 include_directories(
     ${SDKROOT}/libjpeg-turbo64/include
     ${OpenCV_INCLUDE_DIRS}

--- a/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
+++ b/toonz/sources/image/ffmpeg/tiio_ffmpeg.cpp
@@ -46,7 +46,14 @@ bool Ffmpeg::checkFfmpeg() {
     }
 #endif
 
-  // give up
+#ifdef LINUX
+	path = QDir::currentPath() + "/ffmpeg/ffmpeg";
+	if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
+		Preferences::instance()->setValue(ffmpegPath, QDir::currentPath() + "/ffmpeg/");
+		return true;
+	}
+#endif
+	// give up
   return false;
 }
 
@@ -76,7 +83,15 @@ bool Ffmpeg::checkFfprobe() {
     }
 #endif
 
-  // give up
+#ifdef LINUX
+	path = QDir::currentPath() + "/ffmpeg/ffprobe";
+	if (TSystem::doesExistFileOrLevel(TFilePath(path))) {
+		Preferences::instance()->setValue(ffmpegPath, QDir::currentPath() + "/ffmpeg/");
+		return true;
+	}
+#endif
+
+	// give up
   return false;
 }
 


### PR DESCRIPTION
This PR adds a script to build Tahoma on macOS and linux environments.

These scripts are not intended for building PRs through Travis as the artifacts are not able to be added to the PR. They can be used for master Travis builds without Canon support. The master build artifacts can be added to a nightlies page at a later date.

These were made for macOS 10.13 (High Sierra) and Ubuntu 16.04 (Xenial).

Building steps (replace `env` with `osx` or `linux`):
1. Go to root of Tahoma repository

2. Run install script 1x to download and install precompiled packages (brew on macOS, apt-get on Ubuntu)
```
$ ci-scripts/env/tahoma-install.sh
```

3. Run ffmpeg build script 1x to download ffmpeg source and compile options for LGPL license
```
$ ci-scripts/env/tahoma-buildffmpeg.sh
```
NOTE:
   - Linux build also includes downloading and compiling openH264. openH264is brew'd in for macOS builds.
   - Downloaded source found and compiled in `thirdparty/openh264` (linux only) and `thirdparty/ffmpeg`.

4. Run opencv build script 1x to download opencv source and compile
```
$ ci-scripts/env/tahoma-buildopencv.sh
```
NOTE:
   - Downloaded source found and compiled in `thirdparty/opencv`.

5. Run Tahoma build script as needed
```
$ ci-scripts/env/tahoma-build.sh
```
NOTE:
   - If `thirdparty/canon/Header` directory is detected, it will automatically build with WITH_CANON flag

6. Run packaging script to build Tahoma.app (in Tahoma-osx.dmg) for macOS/Tahoma.AppImage (in Tahoma-linux.tar.gz) for linux
```
$ ci-scripts/env/tahoma-buildpkg.sh
```
NOTE: 
   - If `thirdparty/ffmpeg/bin` directory is detected, it will package the binaries with the release.
   - The compiled ffmpeg binaries from step 3 are not used for packaging, yet, because I need to work on building stand alone ffmpeg binaries.  The compiled version expects certain shared libraries are already installed so may not work on other machines.
