### PR TITLE
Allow Smart Raster and Raster brushes to snap every 15 degrees

### DIFF
--- a/toonz/sources/tnztools/fullcolorbrushtool.cpp
+++ b/toonz/sources/tnztools/fullcolorbrushtool.cpp
@@ -504,25 +504,52 @@ void FullColorBrushTool::leftButtonDrag(const TPointD &pos,
       double denominator = m_lastPoint.x - m_firstPoint.x;
       if (denominator == 0) denominator == 0.001;
       double slope = ((m_lastPoint.y - m_firstPoint.y) / denominator);
-      double angle = std::atan(slope) * (180 / 3.14159);
-      if (abs(angle) > 67.5)
+      double radAngle = std::atan(abs(slope));
+      double angle = radAngle * (180 / 3.14159);
+      if (abs(angle) >= 82.5)
         m_lastPoint.x = m_firstPoint.x;
-      else if (abs(angle) < 22.5)
+      else if (abs(angle) < 7.5)
         m_lastPoint.y = m_firstPoint.y;
       else {
-        double xDistance = m_lastPoint.x - m_firstPoint.x;
-        double yDistance = m_lastPoint.y - m_firstPoint.y;
-        if (abs(xDistance) > abs(yDistance)) {
-          if (abs(yDistance) == yDistance)
-            m_lastPoint.y = m_firstPoint.y + abs(xDistance);
-          else
-            m_lastPoint.y = m_firstPoint.y - abs(xDistance);
-        } else {
-          if (abs(xDistance) == xDistance)
-            m_lastPoint.x = m_firstPoint.x + abs(yDistance);
-          else
-            m_lastPoint.x = m_firstPoint.x - abs(yDistance);
-        }
+          double xDistance = m_lastPoint.x - m_firstPoint.x;
+          double yDistance = m_lastPoint.y - m_firstPoint.y;
+
+          double totalDistance = std::sqrt(std::pow(xDistance, 2) + std::pow(yDistance, 2));
+          double xLength = 0.0;
+          double yLength = 0.0;
+          if (angle >= 7.5 && angle < 22.5) {
+              yLength = std::sin(15 * (3.14159 / 180)) * totalDistance;
+              xLength = std::cos(15 * (3.14159 / 180)) * totalDistance;
+          }
+          else if (angle >= 22.5 && angle < 37.5) {
+              yLength = std::sin(30 * (3.14159 / 180)) * totalDistance;
+              xLength = std::cos(30 * (3.14159 / 180)) * totalDistance;
+          }
+          else if (angle >= 37.5 && angle < 52.5) {
+              yLength = std::sin(45 * (3.14159 / 180)) * totalDistance;
+              xLength = std::cos(45 * (3.14159 / 180)) * totalDistance;
+          }
+          else if (angle >= 52.5 && angle < 67.5) {
+              yLength = std::sin(60 * (3.14159 / 180)) * totalDistance;
+              xLength = std::cos(60 * (3.14159 / 180)) * totalDistance;
+          }
+          else if (angle >= 67.5 && angle < 82.5) {
+              yLength = std::sin(75 * (3.14159 / 180)) * totalDistance;
+              xLength = std::cos(75 * (3.14159 / 180)) * totalDistance;
+          }
+
+          if (yDistance == abs(yDistance)) {
+              m_lastPoint.y = m_firstPoint.y + yLength;
+          }
+          else {
+              m_lastPoint.y = m_firstPoint.y - yLength;
+          }
+          if (xDistance == abs(xDistance)) {
+              m_lastPoint.x = m_firstPoint.x + xLength;
+          }
+          else {
+              m_lastPoint.x = m_firstPoint.x - xLength;
+          }
       }
     }
 

--- a/toonz/sources/tnztools/toonzrasterbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzrasterbrushtool.cpp
@@ -1534,27 +1534,59 @@ void ToonzRasterBrushTool::leftButtonDrag(const TPointD &pos,
           TRectD(TPointD(m_brushPos.x - distance, m_brushPos.y - distance),
                  TPointD(m_brushPos.x + distance, m_brushPos.y + distance));
       invalidateRect += (brushRect);
+
       double denominator = m_lastPoint.x - m_firstPoint.x;
       if (denominator == 0) denominator == 0.001;
       double slope = ((m_lastPoint.y - m_firstPoint.y) / denominator);
-      double angle = std::atan(slope) * (180 / 3.14159);
-      if (abs(angle) > 67.5)
-        m_lastPoint.x = m_firstPoint.x;
-      else if (abs(angle) < 22.5)
-        m_lastPoint.y = m_firstPoint.y;
+      double radAngle = std::atan(abs(slope));
+      double angle = radAngle * (180 / 3.14159);
+      if (abs(angle) >= 82.5) {
+          // make it vertical
+          m_lastPoint.x = m_firstPoint.x;
+      }
+      else if (abs(angle) < 7.5) {
+          // make it horizontal
+          m_lastPoint.y = m_firstPoint.y;
+      }
       else {
         double xDistance = m_lastPoint.x - m_firstPoint.x;
         double yDistance = m_lastPoint.y - m_firstPoint.y;
-        if (abs(xDistance) > abs(yDistance)) {
-          if (abs(yDistance) == yDistance)
-            m_lastPoint.y = m_firstPoint.y + abs(xDistance);
-          else
-            m_lastPoint.y = m_firstPoint.y - abs(xDistance);
-        } else {
-          if (abs(xDistance) == xDistance)
-            m_lastPoint.x = m_firstPoint.x + abs(yDistance);
-          else
-            m_lastPoint.x = m_firstPoint.x - abs(yDistance);
+
+        double totalDistance = std::sqrt(std::pow(xDistance, 2) + std::pow(yDistance, 2));
+        double xLength = 0.0;
+        double yLength = 0.0;
+        if (angle >= 7.5 && angle < 22.5) {
+            yLength = std::sin(15 * (3.14159 / 180)) * totalDistance;
+            xLength = std::cos(15 * (3.14159 / 180)) * totalDistance;
+        }
+        else if (angle >= 22.5 && angle < 37.5) {
+            yLength = std::sin(30 * (3.14159 / 180)) * totalDistance;
+            xLength = std::cos(30 * (3.14159 / 180)) * totalDistance;
+        }
+        else if (angle >= 37.5 && angle < 52.5) {
+            yLength = std::sin(45 * (3.14159 / 180)) * totalDistance;
+            xLength = std::cos(45 * (3.14159 / 180)) * totalDistance;
+        }
+        else if (angle >= 52.5 && angle < 67.5) {
+            yLength = std::sin(60 * (3.14159 / 180)) * totalDistance;
+            xLength = std::cos(60 * (3.14159 / 180)) * totalDistance;
+        }
+        else if (angle >= 67.5 && angle < 82.5) {
+            yLength = std::sin(75 * (3.14159 / 180)) * totalDistance;
+            xLength = std::cos(75 * (3.14159 / 180)) * totalDistance;
+        }
+
+        if (yDistance == abs(yDistance)) {
+            m_lastPoint.y = m_firstPoint.y + yLength;
+        }
+        else {
+            m_lastPoint.y = m_firstPoint.y - yLength;
+        }
+        if (xDistance == abs(xDistance)) {
+            m_lastPoint.x = m_firstPoint.x + xLength;
+        }
+        else {
+            m_lastPoint.x = m_firstPoint.x - xLength;
         }
       }
     }


### PR DESCRIPTION
This changes the control/command behavior with raster and smart raster brushes.  Instead of snapping at 45 degrees, this will allow snapping every 15 degrees.  This adds greater flexibility and will allow for isometric workflows.