### PR TITLE
Add missing icons to qrc file.

### DIFF
--- a/toonz/sources/toonz/toonz.qrc
+++ b/toonz/sources/toonz/toonz.qrc
@@ -517,6 +517,8 @@
 		<file>Resources/motionpath_delete.svg</file>
 		<file>Resources/motionpath_rot.svg</file>
 		<file>Resources/move.png</file>
+		<file>Resources/more.svg</file>
+		<file>Resources/moredown.svg</file>
 		<file>Resources/no_specialstyle.png</file>
 		<file>Resources/no_vectorbrush.png</file>
 		<file>Resources/no_mypaintbrush.png</file>
@@ -552,6 +554,7 @@
 		<file>Resources/shear.png</file>
 		<file>Resources/splash.svg</file>
 		<file>Resources/splash2.svg</file>
+		<file>Resources/startup.png</file>
 		<file>Resources/stroke_select.png</file>
 		<file>Resources/tape.png</file>
 		<file>Resources/touch.svg</file>


### PR DESCRIPTION
This fixes the missing icon in the about window.