### PR TITLE
Fix override warnings

### DIFF
--- a/toonz/sources/image/ffmpeg/tiio_gif.h
+++ b/toonz/sources/image/ffmpeg/tiio_gif.h
@@ -21,12 +21,12 @@ public:
   TLevelWriterGif(const TFilePath &path, TPropertyGroup *winfo);
   ~TLevelWriterGif();
   // FfmpegBridge* ffmpeg;
-  void setFrameRate(double fps);
+  void setFrameRate(double fps) override;
 
   TImageWriterP getFrameWriter(TFrameId fid) override;
   void save(const TImageP &image, int frameIndex);
 
-  void saveSoundTrack(TSoundTrack *st);
+  void saveSoundTrack(TSoundTrack *st) override;
 
   static TLevelWriter *create(const TFilePath &path, TPropertyGroup *winfo) {
     return new TLevelWriterGif(path, winfo);

--- a/toonz/sources/image/ffmpeg/tiio_mp4.h
+++ b/toonz/sources/image/ffmpeg/tiio_mp4.h
@@ -19,12 +19,12 @@ class TLevelWriterMp4 : public TLevelWriter {
 public:
   TLevelWriterMp4(const TFilePath &path, TPropertyGroup *winfo);
   ~TLevelWriterMp4();
-  void setFrameRate(double fps);
+  void setFrameRate(double fps) override;
 
   TImageWriterP getFrameWriter(TFrameId fid) override;
   void save(const TImageP &image, int frameIndex);
 
-  void saveSoundTrack(TSoundTrack *st);
+  void saveSoundTrack(TSoundTrack *st) override;
 
   static TLevelWriter *create(const TFilePath &path, TPropertyGroup *winfo) {
     return new TLevelWriterMp4(path, winfo);

--- a/toonz/sources/image/ffmpeg/tiio_webm.h
+++ b/toonz/sources/image/ffmpeg/tiio_webm.h
@@ -18,12 +18,12 @@ class TLevelWriterWebm : public TLevelWriter {
 public:
   TLevelWriterWebm(const TFilePath &path, TPropertyGroup *winfo);
   ~TLevelWriterWebm();
-  void setFrameRate(double fps);
+  void setFrameRate(double fps) override;
 
   TImageWriterP getFrameWriter(TFrameId fid) override;
   void save(const TImageP &image, int frameIndex);
 
-  void saveSoundTrack(TSoundTrack *st);
+  void saveSoundTrack(TSoundTrack *st) override;
 
   static TLevelWriter *create(const TFilePath &path, TPropertyGroup *winfo) {
     return new TLevelWriterWebm(path, winfo);

--- a/toonz/sources/image/sprite/tiio_sprite.h
+++ b/toonz/sources/image/sprite/tiio_sprite.h
@@ -21,12 +21,12 @@ class TLevelWriterSprite : public TLevelWriter {
 public:
   TLevelWriterSprite(const TFilePath &path, TPropertyGroup *winfo);
   ~TLevelWriterSprite();
-  void setFrameRate(double fps);
+  void setFrameRate(double fps) override;
 
   TImageWriterP getFrameWriter(TFrameId fid) override;
   void save(const TImageP &image, int frameIndex);
 
-  void saveSoundTrack(TSoundTrack *st);
+  void saveSoundTrack(TSoundTrack *st) override;
 
   static TLevelWriter *create(const TFilePath &path, TPropertyGroup *winfo) {
     return new TLevelWriterSprite(path, winfo);

--- a/toonz/sources/include/tools/pinchtool.h
+++ b/toonz/sources/include/tools/pinchtool.h
@@ -63,41 +63,41 @@ public:
   PinchTool();
   virtual ~PinchTool();
 
-  ToolType getToolType() const { return TTool::LevelWriteTool; }
+  ToolType getToolType() const override { return TTool::LevelWriteTool; }
 
   void setShowSelector(bool show) { m_showSelector = show; }
 
-  void onEnter();
-  void onLeave();
+  void onEnter() override;
+  void onLeave() override;
 
-  void updateTranslation();
+  void updateTranslation() override;
 
-  void draw();
+  void draw() override;
 
-  void leftButtonDown(const TPointD &pos, const TMouseEvent &);
+  void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
 
-  void leftButtonDrag(const TPointD &pos, const TMouseEvent &e);
+  void leftButtonDrag(const TPointD &pos, const TMouseEvent &e) override;
 
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &e);
+  void leftButtonUp(const TPointD &pos, const TMouseEvent &e) override;
 
   void invalidateCursorArea();
 
-  void mouseMove(const TPointD &pos, const TMouseEvent &e);
+  void mouseMove(const TPointD &pos, const TMouseEvent &e) override;
 
   bool moveCursor(const TPointD &pos);
 
   bool keyDown(QKeyEvent *) override;
 
-  void onActivate();
-  void onDeactivate();
+  void onActivate() override;
+  void onDeactivate() override;
 
   // viene usato??
   void update(const TGlobalChange &);
 
-  void onImageChanged();
+  void onImageChanged() override;
 
-  int getCursorId() const { return updateCursor(); }
-  TPropertyGroup *getProperties(int targetType) { return &m_prop; }
+  int getCursorId() const override { return updateCursor(); }
+  TPropertyGroup *getProperties(int targetType) override { return &m_prop; }
 };
 
 #endif  // PINCHTOOL_H

--- a/toonz/sources/include/tools/tooloptions.h
+++ b/toonz/sources/include/tools/tooloptions.h
@@ -696,7 +696,7 @@ class ShiftTraceToolOptionBox final : public ToolOptionsBox {
   void resetGhost(int index);
 
 protected:
-  void showEvent(QShowEvent *);
+  void showEvent(QShowEvent *) override;
   void hideEvent(QShowEvent *);
 
 public:

--- a/toonz/sources/include/toonz/stagevisitor.h
+++ b/toonz/sources/include/toonz/stagevisitor.h
@@ -351,7 +351,7 @@ public:
 
   void onImage(const Stage::Player &data) override;
   void onVectorImage(TVectorImage *vi, const Stage::Player &data);
-  void onRasterImage(TRasterImage *ri, const Stage::Player &data);
+  void onRasterImage(TRasterImage *ri, const Stage::Player &data) override;
   void onToonzImage(TToonzImage *ti, const Stage::Player &data);
 
   void beginMask() override;

--- a/toonz/sources/include/toonzqt/schematicviewer.h
+++ b/toonz/sources/include/toonzqt/schematicviewer.h
@@ -152,9 +152,9 @@ protected:
   void showEvent(QShowEvent *se) override;
   void enterEvent(QEvent *e) override;
   void leaveEvent(QEvent *e) override;
-  void mouseDoubleClickEvent(QMouseEvent *event);
+  void mouseDoubleClickEvent(QMouseEvent *event) override;
 
-  void tabletEvent(QTabletEvent *e);
+  void tabletEvent(QTabletEvent *e) override;
   void touchEvent(QTouchEvent *e, int type);
   void gestureEvent(QGestureEvent *e);
 

--- a/toonz/sources/stdfx/ino_line_blur.cpp
+++ b/toonz/sources/stdfx/ino_line_blur.cpp
@@ -6536,7 +6536,7 @@ public:
       bBox = bBox.enlarge(static_cast<double>(margin));
     }
   }
-  bool doGetBBox(double frame, TRectD &bBox, const TRenderSettings &info) {
+  bool doGetBBox(double frame, TRectD &bBox, const TRenderSettings &info) override {
     if (false == this->m_input.isConnected()) {
       bBox = TRectD();
       return false;
@@ -6546,23 +6546,23 @@ public:
     return ret;
   }
   int getMemoryRequirement(const TRectD &rect, double frame,
-                           const TRenderSettings &info) {
+                           const TRenderSettings &info) override {
     TRectD bBox(rect);
     this->get_render_enlarge(frame, info.m_affine, bBox);
     return TRasterFx::memorySize(bBox, info.m_bpp);
   }
   void transform(double frame, int port, const TRectD &rectOnOutput,
                  const TRenderSettings &infoOnOutput, TRectD &rectOnInput,
-                 TRenderSettings &infoOnInput) {
+                 TRenderSettings &infoOnInput) override {
     rectOnInput = rectOnOutput;
     infoOnInput = infoOnOutput;
     this->get_render_enlarge(frame, infoOnOutput.m_affine, rectOnInput);
   }
-  bool canHandle(const TRenderSettings &info, double frame) {
+  bool canHandle(const TRenderSettings &info, double frame) override {
     // return true;/* geometry処理済の画像に加工することになる */
     return false; /* ここでの処理後にgeometryがかかる */
   }
-  void doCompute(TTile &tile, double frame, const TRenderSettings &rend_sets);
+  void doCompute(TTile &tile, double frame, const TRenderSettings &rend_sets) override;
 };
 
 FX_PLUGIN_IDENTIFIER(ino_line_blur, "inoLineBlurFx");

--- a/toonz/sources/stdfx/iwa_bokehfx.h
+++ b/toonz/sources/stdfx/iwa_bokehfx.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 /*------------------------------------
 Iwa_BokehFx
@@ -139,11 +139,11 @@ protected:
 public:
   Iwa_BokehFx();
 
-  void doCompute(TTile &tile, double frame, const TRenderSettings &settings);
+  void doCompute(TTile &tile, double frame, const TRenderSettings &settings) override;
 
-  bool doGetBBox(double frame, TRectD &bBox, const TRenderSettings &info);
+  bool doGetBBox(double frame, TRectD &bBox, const TRenderSettings &info) override;
 
-  bool canHandle(const TRenderSettings &info, double frame);
+  bool canHandle(const TRenderSettings &info, double frame) override;
 };
 
 #endif

--- a/toonz/sources/stdfx/iwa_bokehreffx.h
+++ b/toonz/sources/stdfx/iwa_bokehreffx.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 /*------------------------------------
 Iwa_BokehRefFx
@@ -176,11 +176,11 @@ protected:
 public:
   Iwa_BokehRefFx();
 
-  void doCompute(TTile& tile, double frame, const TRenderSettings& settings);
+  void doCompute(TTile& tile, double frame, const TRenderSettings& settings) override;
 
-  bool doGetBBox(double frame, TRectD& bBox, const TRenderSettings& info);
+  bool doGetBBox(double frame, TRectD& bBox, const TRenderSettings& info) override;
 
-  bool canHandle(const TRenderSettings& info, double frame);
+  bool canHandle(const TRenderSettings& info, double frame) override;
 
   void doCompute_CPU(const double frame, const TRenderSettings& settings,
                      float bokehPixelAmount, float maxIrisSize, int margin,

--- a/toonz/sources/stdfx/iwa_glarefx.h
+++ b/toonz/sources/stdfx/iwa_glarefx.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 
 /*------------------------------------
 Iwa_GlareFx
@@ -89,11 +89,11 @@ protected:
 public:
   Iwa_GlareFx();
 
-  void doCompute(TTile &tile, double frame, const TRenderSettings &settings);
+  void doCompute(TTile &tile, double frame, const TRenderSettings &settings) override;
 
-  bool doGetBBox(double frame, TRectD &bBox, const TRenderSettings &info);
+  bool doGetBBox(double frame, TRectD &bBox, const TRenderSettings &info) override;
 
-  bool canHandle(const TRenderSettings &info, double frame);
+  bool canHandle(const TRenderSettings &info, double frame) override;
 
   void getParamUIs(TParamUIConcept *&concepts, int &length) override;
 };

--- a/toonz/sources/tnztools/rasterselectiontool.h
+++ b/toonz/sources/tnztools/rasterselectiontool.h
@@ -242,7 +242,7 @@ public:
   bool onPropertyChanged(std::string propertyName) override;
   bool getNoAntialiasingValue() { return m_noAntialiasing.getValue(); }
 
-  bool isSelectionEditable() { return m_rasterSelection.isEditable(); }
+  bool isSelectionEditable() override { return m_rasterSelection.isEditable(); }
 
 protected:
   void updateTranslation() override;

--- a/toonz/sources/tnztools/skeletontool.h
+++ b/toonz/sources/tnztools/skeletontool.h
@@ -79,25 +79,25 @@ public:
   SkeletonTool();
   ~SkeletonTool();
 
-  ToolType getToolType() const { return TTool::ColumnTool; }
+  ToolType getToolType() const override { return TTool::ColumnTool; }
 
-  void updateTranslation();  // QString localization stuff
+  void updateTranslation() override;  // QString localization stuff
 
   bool doesApply() const;  // ritorna vero se posso deformare l'oggetto corrente
 
-  void onEnter() {}
-  void leftButtonDown(const TPointD &pos, const TMouseEvent &);
-  void leftButtonDrag(const TPointD &pos, const TMouseEvent &);
-  void leftButtonUp(const TPointD &pos, const TMouseEvent &);
-  void mouseMove(const TPointD &, const TMouseEvent &e);
+  void onEnter() override {}
+  void leftButtonDown(const TPointD &pos, const TMouseEvent &) override;
+  void leftButtonDrag(const TPointD &pos, const TMouseEvent &) override;
+  void leftButtonUp(const TPointD &pos, const TMouseEvent &) override;
+  void mouseMove(const TPointD &, const TMouseEvent &e) override;
 
-  void onImageChanged() { invalidate(); }
+  void onImageChanged() override { invalidate(); }
 
-  void reset() { m_temporaryPinnedColumns.clear(); }
+  void reset() override { m_temporaryPinnedColumns.clear(); }
 
-  bool onPropertyChanged(std::string propertyName);
+  bool onPropertyChanged(std::string propertyName) override;
 
-  void draw();
+  void draw() override;
 
   void drawSkeleton(const Skeleton &skeleton, int row);
   void drawLevelBoundingBox(int frame, int columnIndex);
@@ -122,21 +122,21 @@ public:
 
   bool keyDown(QKeyEvent *event) override;
 
-  void onActivate();
-  void onDeactivate();
+  void onActivate() override;
+  void onDeactivate() override;
 
   int getMagicLinkCount() const { return (int)m_magicLinks.size(); }
   SkeletonSubtools::MagicLink getMagicLink(int index) const;
 
   void magicLink(int index);
 
-  int getCursorId() const;
+  int getCursorId() const override;
 
   // TRaster32P getToolIcon() const {return Pixmaps::arrow;}
-  TPropertyGroup *getProperties(int targetType) { return &m_prop; }
+  TPropertyGroup *getProperties(int targetType) override { return &m_prop; }
 
-  void updateMatrix() { setMatrix(getCurrentObjectParentMatrix()); }
-  void addContextMenuItems(QMenu *menu);
+  void updateMatrix() override { setMatrix(getCurrentObjectParentMatrix()); }
+  void addContextMenuItems(QMenu *menu) override;
   bool select(const TSelection *) { return false; }
 
   void togglePinnedStatus(int columnIndex, int frame, bool shiftPressed);

--- a/toonz/sources/tnztools/stylepickertool.h
+++ b/toonz/sources/tnztools/stylepickertool.h
@@ -42,7 +42,7 @@ public:
 
   int getCursorId() const override;
 
-  bool onPropertyChanged(std::string propertyName);
+  bool onPropertyChanged(std::string propertyName) override;
 
   bool isOrganizePaletteActive() { return m_organizePalette.getValue(); }
 

--- a/toonz/sources/tnztools/vectorselectiontool.h
+++ b/toonz/sources/tnztools/vectorselectiontool.h
@@ -312,7 +312,7 @@ public:
   void setResetCenter(bool update) { m_resetCenter = update; }
   bool canResetCenter() { return m_resetCenter; }
 
-  bool isSelectionEditable() { return m_strokeSelection.isEditable(); }
+  bool isSelectionEditable() override { return m_strokeSelection.isEditable(); }
 
 protected:
   void onActivate() override;

--- a/toonz/sources/tnztools/viewtools.h
+++ b/toonz/sources/tnztools/viewtools.h
@@ -37,7 +37,7 @@ public:
 
   int getCursorId() const override;
 
-  void updateTranslation() {
+  void updateTranslation() override {
     m_cameraCentered.setQStringName(tr("Rotate On Camera Center"));
   }
 };

--- a/toonz/sources/toonz/filebrowserpopup.h
+++ b/toonz/sources/toonz/filebrowserpopup.h
@@ -218,7 +218,7 @@ protected:
   void showEvent(QShowEvent *) override;
 
 protected slots:
-  void onFilePathDoubleClicked(const TFilePath &path);
+  void onFilePathDoubleClicked(const TFilePath &path) override;
 };
 
 //-----------------------------------------------------------------------------
@@ -313,7 +313,7 @@ protected slots:
   // the selection
   void onSelectionChanged(TSelection *selection);
 
-  void onFilePathDoubleClicked(const TFilePath &path);
+  void onFilePathDoubleClicked(const TFilePath &path) override;
 
   void onPreferenceChanged(const QString &);
 

--- a/toonz/sources/toonz/imageviewer.h
+++ b/toonz/sources/toonz/imageviewer.h
@@ -144,10 +144,10 @@ protected:
 
   void dragCompare(const QPoint &dp);
 
-  void tabletEvent(QTabletEvent *e);
+  void tabletEvent(QTabletEvent *e) override;
   void touchEvent(QTouchEvent *e, int type);
   void gestureEvent(QGestureEvent *e);
-  bool event(QEvent *e);
+  bool event(QEvent *e) override;
 
 public slots:
 

--- a/toonz/sources/toonz/layerheaderpanel.h
+++ b/toonz/sources/toonz/layerheaderpanel.h
@@ -46,8 +46,8 @@ protected:
   void mousePressEvent(QMouseEvent *event) override;
   void mouseMoveEvent(QMouseEvent *event) override;
   void mouseReleaseEvent(QMouseEvent *event) override;
-  void enterEvent(QEvent *);
-  void leaveEvent(QEvent *);
+  void enterEvent(QEvent *) override;
+  void leaveEvent(QEvent *) override;
   bool event(QEvent *event) override;
 
 private:

--- a/toonz/sources/toonz/penciltestpopup.h
+++ b/toonz/sources/toonz/penciltestpopup.h
@@ -279,9 +279,9 @@ public:
   ~PencilTestPopup();
 
 protected:
-  void showEvent(QShowEvent* event);
-  void hideEvent(QHideEvent* event);
-  void keyPressEvent(QKeyEvent* event);
+  void showEvent(QShowEvent* event) override;
+  void hideEvent(QHideEvent* event) override;
+  void keyPressEvent(QKeyEvent* event) override;
 
   bool event(QEvent* e) override;
 

--- a/toonz/sources/toonz/sceneviewer.h
+++ b/toonz/sources/toonz/sceneviewer.h
@@ -285,8 +285,8 @@ public:
   bool canSwapCompared() const;
 
   bool isEditPreviewSubcamera() const { return m_editPreviewSubCamera; }
-  bool getIsFlippedX() const { return m_isFlippedX; }
-  bool getIsFlippedY() const { return m_isFlippedY; }
+  bool getIsFlippedX() const override { return m_isFlippedX; }
+  bool getIsFlippedY() const override { return m_isFlippedY; }
   void setEditPreviewSubcamera(bool enabled) {
     m_editPreviewSubCamera = enabled;
   }
@@ -307,10 +307,10 @@ public:
 
   void setIsLocator() { m_isLocator = true; }
   void setIsStyleShortcutSwitchable() { m_isStyleShortcutSwitchable = true; }
-  int getVGuideCount();
-  int getHGuideCount();
-  double getVGuide(int index);
-  double getHGuide(int index);
+  int getVGuideCount() override;
+  int getHGuideCount() override;
+  double getVGuide(int index) override;
+  double getHGuide(int index) override;
 
   void bindFBO() override;
   void releaseFBO() override;

--- a/toonz/sources/toonzlib/imagebuilders.h
+++ b/toonz/sources/toonzlib/imagebuilders.h
@@ -61,7 +61,7 @@ public:
 
   /* Exposed to allow Fid to be updated due to a renumber operation
   */
-  void setFid(const TFrameId &fid);
+  void setFid(const TFrameId &fid) override;
 
 protected:
   bool getInfo(TImageInfo &info, int imFlags, void *extData) override;

--- a/toonz/sources/toonzlib/tpalettehandle.cpp
+++ b/toonz/sources/toonzlib/tpalettehandle.cpp
@@ -32,7 +32,7 @@ public:
 
   void redo() const override { toggleAutopaint(); }
 
-  void onAdd() { redo(); }
+  void onAdd() override { redo(); }
 
   int getSize() const override { return sizeof(*this); }
 


### PR DESCRIPTION
There are 100+ warnings due to ______ overriding a member function without being marked override. This adds override in those cases to silence the warnings.
<img width="234" alt="Screen Shot 2020-09-11 at 10 59 25 PM" src="https://user-images.githubusercontent.com/21159116/92985768-a5562200-f483-11ea-9ab3-0c714a39619b.png">