### PR TITLE
Make main window transparent for reference work.

### DIFF
--- a/stuff/profiles/layouts/rooms/Default/menubar_template.xml
+++ b/stuff/profiles/layouts/rooms/Default/menubar_template.xml
@@ -277,6 +277,7 @@
         <command>MI_RasterizePli</command>
         <separator/>
         <command>MI_ShowStatusBar</command>
+        <command>MI_ToggleTransparent</command>
         <separator/>
         <command>MI_MaximizePanel</command>
         <command>MI_FullScreenWindow</command>

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -2228,6 +2228,29 @@ void MainWindow::defineActions() {
   connect(showStatusBarAction, SIGNAL(triggered(bool)), this,
           SLOT(toggleStatusBar(bool)));
 
+  QAction *toggleTransparencyAction =
+      createToggle(MI_ToggleTransparent, tr("&Toggle Transparency"), "", 0,
+                   MenuViewCommandType);
+  connect(toggleTransparencyAction, SIGNAL(triggered(bool)), this,
+          SLOT(toggleTransparency(bool)));
+
+  m_transparencyTogglerWindow = new QDialog();
+  m_transparencyTogglerWindow->setWindowFlags(Qt::WindowStaysOnTopHint |
+                                              Qt::WindowCloseButtonHint);
+  connect(m_transparencyTogglerWindow, &QDialog::finished, [=](int result) {
+    toggleTransparency(false);
+    toggleTransparencyAction->setChecked(false);
+  });
+  m_transparencyTogglerWindow->setFixedHeight(50);
+  m_transparencyTogglerWindow->setFixedWidth(250);
+  QPushButton *toggleButton = new QPushButton(this);
+  toggleButton->setText(tr("Click to reset Tahoma transparency."));
+  connect(toggleButton, &QPushButton::clicked,
+          [=]() { m_transparencyTogglerWindow->accept(); });
+  QVBoxLayout *togglerLayout = new QVBoxLayout(this);
+  togglerLayout->addWidget(toggleButton);
+  m_transparencyTogglerWindow->setLayout(togglerLayout);
+
   toggle = createToggle(MI_ShiftTrace, tr("Shift and Trace"), "", false,
                         MenuViewCommandType);
   toggle->setIcon(createQIcon("shift_and_trace"));
@@ -3642,11 +3665,30 @@ void MainWindow::toggleStatusBar(bool on) {
 
 //-----------------------------------------------------------------------------
 
+void MainWindow::toggleTransparency(bool on) {
+  if (!on) {
+    this->setProperty("windowOpacity", 1.0);
+  } else {
+    this->setProperty("windowOpacity", 0.5);
+    m_transparencyTogglerWindow->show();
+  }
+}
+
+//-----------------------------------------------------------------------------
+
 class ToggleStatusBar final : public MenuItemHandler {
 public:
   ToggleStatusBar() : MenuItemHandler("MI_ShowStatusBar") {}
   void execute() override {}
 } toggleStatusBar;
+
+//-----------------------------------------------------------------------------
+
+class ToggleTransparency final : public MenuItemHandler {
+public:
+  ToggleTransparency() : MenuItemHandler("MI_ToggleTransparent") {}
+  void execute() override {}
+} toggleTransparency;
 
 //-----------------------------------------------------------------------------
 

--- a/toonz/sources/toonz/mainwindow.cpp
+++ b/toonz/sources/toonz/mainwindow.cpp
@@ -377,6 +377,7 @@ MainWindow::MainWindow(const QString &argumentLayoutFileName, QWidget *parent,
   m_toolsActionGroup = new QActionGroup(this);
   m_toolsActionGroup->setExclusive(true);
   m_currentRoomsChoice = Preferences::instance()->getCurrentRoomChoice();
+  makeTransparencyDialog();
   defineActions();
   // user defined shortcuts will be loaded here
   CommandManager::instance()->loadShortcuts();
@@ -2233,23 +2234,10 @@ void MainWindow::defineActions() {
                    MenuViewCommandType);
   connect(toggleTransparencyAction, SIGNAL(triggered(bool)), this,
           SLOT(toggleTransparency(bool)));
-
-  m_transparencyTogglerWindow = new QDialog();
-  m_transparencyTogglerWindow->setWindowFlags(Qt::WindowStaysOnTopHint |
-                                              Qt::WindowCloseButtonHint);
   connect(m_transparencyTogglerWindow, &QDialog::finished, [=](int result) {
     toggleTransparency(false);
     toggleTransparencyAction->setChecked(false);
   });
-  m_transparencyTogglerWindow->setFixedHeight(50);
-  m_transparencyTogglerWindow->setFixedWidth(250);
-  QPushButton *toggleButton = new QPushButton(this);
-  toggleButton->setText(tr("Click to reset Tahoma transparency."));
-  connect(toggleButton, &QPushButton::clicked,
-          [=]() { m_transparencyTogglerWindow->accept(); });
-  QVBoxLayout *togglerLayout = new QVBoxLayout(this);
-  togglerLayout->addWidget(toggleButton);
-  m_transparencyTogglerWindow->setLayout(togglerLayout);
 
   toggle = createToggle(MI_ShiftTrace, tr("Shift and Trace"), "", false,
                         MenuViewCommandType);
@@ -3665,13 +3653,53 @@ void MainWindow::toggleStatusBar(bool on) {
 
 //-----------------------------------------------------------------------------
 
-void MainWindow::toggleTransparency(bool on) {
+void MainWindow::toggleTransparency(bool on, double value) {
   if (!on) {
     this->setProperty("windowOpacity", 1.0);
   } else {
-    this->setProperty("windowOpacity", 0.5);
+    this->setProperty("windowOpacity", value);
     m_transparencyTogglerWindow->show();
   }
+}
+
+//-----------------------------------------------------------------------------
+
+void MainWindow::makeTransparencyDialog() {
+  m_transparencyTogglerWindow = new QDialog();
+  m_transparencyTogglerWindow->setWindowFlags(Qt::WindowStaysOnTopHint |
+                                              Qt::WindowCloseButtonHint);
+
+  m_transparencyTogglerWindow->setFixedHeight(100);
+  m_transparencyTogglerWindow->setFixedWidth(250);
+  m_transparencyTogglerWindow->setWindowTitle(tr("Tahoma Transparency"));
+  QPushButton *toggleButton = new QPushButton(this);
+  toggleButton->setText(tr("Click to reset Tahoma transparency."));
+  connect(toggleButton, &QPushButton::clicked,
+          [=]() { m_transparencyTogglerWindow->accept(); });
+  QSlider *transparencySlider = new QSlider(this);
+  transparencySlider->setRange(30, 100);
+  transparencySlider->setValue(50);
+  transparencySlider->setOrientation(Qt::Horizontal);
+  connect(transparencySlider, &QSlider::valueChanged,
+          [=](int value) { toggleTransparency(true, (double)value / 100); });
+  // connect(static_cast<QApplication*>(QApplication::instance()),
+  // &QApplication::applicationStateChanged,
+  //    [=](Qt::ApplicationState state) {
+  //        if (state == Qt::ApplicationActive)
+  //            m_transparencyTogglerWindow->setWindowFlags(Qt::WindowStaysOnTopHint);
+  //        else
+  //            m_transparencyTogglerWindow->setWindowFlags(m_transparencyTogglerWindow->windowFlags()
+  //            & ~Qt::WindowStaysOnTopHint);
+  //    });
+
+  QVBoxLayout *togglerLayout       = new QVBoxLayout(this);
+  QHBoxLayout *togglerSliderLayout = new QHBoxLayout(this);
+  togglerSliderLayout->addWidget(new QLabel(tr("Amount: "), this));
+  togglerSliderLayout->addWidget(transparencySlider);
+  togglerLayout->addLayout(togglerSliderLayout);
+  togglerLayout->addWidget(toggleButton);
+
+  m_transparencyTogglerWindow->setLayout(togglerLayout);
 }
 
 //-----------------------------------------------------------------------------

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -315,7 +315,8 @@ protected slots:
   void onUpdateCheckerDone(bool);
 
   void toggleStatusBar(bool);
-  void toggleTransparency(bool);
+  void toggleTransparency(bool, double value = 0.5);
+  void makeTransparencyDialog();
 
 public slots:
   /*--- タイトルにシーン名を入れる ---*/

--- a/toonz/sources/toonz/mainwindow.h
+++ b/toonz/sources/toonz/mainwindow.h
@@ -67,6 +67,7 @@ class MainWindow final : public QMainWindow {
   TopBar *m_topBar;
   StatusBar *m_statusBar;
   AboutPopup *m_aboutPopup;
+  QDialog *m_transparencyTogglerWindow;
   QActionGroup *m_toolsActionGroup;
 
   QStackedWidget *m_stackedWidget;
@@ -314,6 +315,7 @@ protected slots:
   void onUpdateCheckerDone(bool);
 
   void toggleStatusBar(bool);
+  void toggleTransparency(bool);
 
 public slots:
   /*--- タイトルにシーン名を入れる ---*/

--- a/toonz/sources/toonz/menubar.cpp
+++ b/toonz/sources/toonz/menubar.cpp
@@ -666,6 +666,7 @@ QMenuBar *StackedMenuBar::createFullMenuBar() {
   addMenuItem(viewMenu, MI_RasterizePli);
   viewMenu->addSeparator();
   addMenuItem(viewMenu, MI_ShowStatusBar);
+  addMenuItem(viewMenu, MI_ToggleTransparent);
   viewMenu->addSeparator();
   addMenuItem(viewMenu, MI_MaximizePanel);
   addMenuItem(viewMenu, MI_FullScreenWindow);

--- a/toonz/sources/toonz/menubarcommandids.h
+++ b/toonz/sources/toonz/menubarcommandids.h
@@ -215,6 +215,7 @@
 
 // #define MI_DockingCheck "MI_DockingCheck"
 #define MI_ShowStatusBar "MI_ShowStatusBar"
+#define MI_ToggleTransparent "MI_ToggleTransparent"
 
 #define MI_OpenFileViewer "MI_OpenFileViewer"
 #define MI_OpenFileBrowser2 "MI_OpenFileBrowser2"


### PR DESCRIPTION
This creates a new option in the view menu to make the main window semi-transparent.  This is to make using references easier (or for watching YouTube while you animate.)

![transparent](https://user-images.githubusercontent.com/4576381/93012618-0ef72e80-f55f-11ea-90ee-c5254479629e.PNG)
