### PR TITLE
Toggle Vector Snapping with Control + Shift

### DIFF
--- a/toonz/sources/tnztools/toonzvectorbrushtool.cpp
+++ b/toonz/sources/tnztools/toonzvectorbrushtool.cpp
@@ -959,7 +959,7 @@ void ToonzVectorBrushTool::leftButtonDrag(const TPointD &pos,
   m_foundLastSnap  = false;
   m_foundFirstSnap = false;
   m_snapSelf       = false;
-  m_toggleSnap     = e.isAltPressed() && !e.isCtrlPressed();
+  m_toggleSnap = !e.isAltPressed() && e.isCtrlPressed() && e.isShiftPressed();
 
   if (!nonShiftStraight) {
       checkStrokeSnapping(false, m_toggleSnap);
@@ -1521,7 +1521,7 @@ void ToonzVectorBrushTool::mouseMove(const TPointD &pos, const TMouseEvent &e) {
 
   m_firstSnapPoint = pos;
   m_foundFirstSnap = false;
-  m_toggleSnap = e.isAltPressed() && !e.isCtrlPressed();
+  m_toggleSnap = !e.isAltPressed() && e.isCtrlPressed() && e.isShiftPressed();
   checkStrokeSnapping(true, m_toggleSnap);
   checkGuideSnapping(true, m_toggleSnap);
   m_brushPos = m_firstSnapPoint;

--- a/toonz/sources/toonz/statusbar.cpp
+++ b/toonz/sources/toonz/statusbar.cpp
@@ -131,17 +131,20 @@ void StatusBar::makeMap() {
   m_infoMap.insert(
       {"T_BrushVector", "Brush Tool: Draws in the work area freehand" + spacer +
                             "Shift - Straight Lines" + spacer +
-                            "Hold Alt - Toggle Snapping"});
+                        "Control - Straight Lines Snapped to Angles" + spacer +
+                        "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
+                        "Alt - Draw to Vanishing Point" + spacer +
+                            "Hold Ctrl + Shift - Toggle Snapping"});
   m_infoMap.insert({"T_BrushSmartRaster",
                     "Brush Tool: Draws in the work area freehand" + spacer +
                         "Shift - Straight Lines" + spacer +
-                        "Control - Vertical and Horizontal Lines" + spacer +
+                        "Control - Straight Lines Snapped to Angles" + spacer +
                         "Ctrl + Alt - Add / Remove Vanishing Point" + spacer +
                         "Alt - Draw to Vanishing Point"});
   m_infoMap.insert(
       {"T_BrushRaster", "Brush Tool: Draws in the work area freehand" + spacer +
                             "Shift - Straight Lines" + spacer +
-                            "Control - Vertical and Horizontal Lines" + spacer +
+                            "Control - Straight Lines Snapped to Angles" + spacer +
                             "Ctrl + Alt - Add / Remove Vanishing Point" +
                             spacer + "Alt - Draw to Vanishing Point"});
   m_infoMap.insert({"T_Geometric", "Geometry Tool: Draws geometric shapes"});


### PR DESCRIPTION
With the new options in the vector brush, I forgot to change the key for snapping toggle.  It is now ctrl + shift.  The only free modifier key combo for vector is now alt + shift.

This also updates the status bar tips for the vector brush.