### PR TITLE
Paste clipboard images (from outside Tahoma) into Tahoma

### DIFF
--- a/toonz/sources/include/tools/rasterselection.h
+++ b/toonz/sources/include/tools/rasterselection.h
@@ -56,9 +56,8 @@ class DVAPI RasterSelection final : public TSelection {
   bool m_noAntialiasing;
 
 private:
-  void pasteSelection(const RasterImageData *data);
-
 public:
+  void pasteSelection(const RasterImageData *data);
   RasterSelection();
   RasterSelection(const RasterSelection &src);
 
@@ -70,7 +69,7 @@ public:
   void setCurrentImage(const TImageP &img, const TXshCell &imageCell) {
     m_currentImage = img, m_currentImageCell = imageCell;
   }
-
+  void setCurrentImageCell(TXshCell cell) { m_currentImageCell = cell; }
   void setStrokes(const std::vector<TStroke> &strokes) { m_strokes = strokes; }
   std::vector<TStroke> getStrokes() const { return m_strokes; }
   std::vector<TStroke> getOriginalStrokes() const { return m_originalStrokes; }

--- a/toonz/sources/include/tools/rasterselection.h
+++ b/toonz/sources/include/tools/rasterselection.h
@@ -54,11 +54,11 @@ class DVAPI RasterSelection final : public TSelection {
   int m_transformationCount;
   bool m_isPastedSelection;
   bool m_noAntialiasing;
-  bool m_fromCellSelection = false;
 
 private:
-public:
   void pasteSelection(const RasterImageData *data);
+
+public:
   RasterSelection();
   RasterSelection(const RasterSelection &src);
 
@@ -70,7 +70,6 @@ public:
   void setCurrentImage(const TImageP &img, const TXshCell &imageCell) {
     m_currentImage = img, m_currentImageCell = imageCell;
   }
-  void setCurrentImageCell(TXshCell cell) { m_currentImageCell = cell; }
   void setStrokes(const std::vector<TStroke> &strokes) { m_strokes = strokes; }
   std::vector<TStroke> getStrokes() const { return m_strokes; }
   std::vector<TStroke> getOriginalStrokes() const { return m_originalStrokes; }
@@ -145,8 +144,6 @@ Can be different from getSelectionBound() after a free deform transformation. */
   bool isTransformed();
 
   bool isEditable();
-
-  void setIncoming() { m_fromCellSelection = true; }
 };
 
 #endif  // RASTER_SELECTION_H

--- a/toonz/sources/include/tools/rasterselection.h
+++ b/toonz/sources/include/tools/rasterselection.h
@@ -54,6 +54,7 @@ class DVAPI RasterSelection final : public TSelection {
   int m_transformationCount;
   bool m_isPastedSelection;
   bool m_noAntialiasing;
+  bool m_fromCellSelection = false;
 
 private:
 public:
@@ -144,6 +145,8 @@ Can be different from getSelectionBound() after a free deform transformation. */
   bool isTransformed();
 
   bool isEditable();
+
+  void setIncoming() { m_fromCellSelection = true; }
 };
 
 #endif  // RASTER_SELECTION_H

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -1042,6 +1042,8 @@ void RasterSelection::pasteFloatingSelection() {
   pasteFloatingSelectionWithoutUndo(m_currentImage, m_floatingSelection,
                                     m_affine, wRect, m_noAntialiasing);
 
+  TXshSimpleLevel* sl = m_currentImageCell.getSimpleLevel();
+  TFrameId id = m_currentImageCell.getFrameId();
   ToolUtils::updateSaveBox(m_currentImageCell.getSimpleLevel(),
                            m_currentImageCell.getFrameId());
 
@@ -1250,6 +1252,32 @@ void RasterSelection::pasteSelection() {
                             clipImage.height() / 2));
 
     riData = qimageData;
+  }
+
+  if (m_fromCellSelection && riData) {
+      m_fromCellSelection = false;
+      std::vector<TRectD> rect;
+      double currentDpiX, currentDpiY;
+      double dpiX, dpiY;
+      std::vector<TStroke> strokes;
+      std::vector<TStroke> originalStrokes;
+      TAffine affine;
+      const FullColorImageData* fullColorData =
+          dynamic_cast<const FullColorImageData*>(riData);
+
+      if (TRasterImageP ri = (TRasterImageP)m_currentImage) {
+          ri->getDpi(currentDpiX, currentDpiY);
+          TRasterP ras;
+          riData->getData(ras, dpiX, dpiY, rect, strokes, originalStrokes,
+              affine, ri->getPalette());
+          if (strokes.size() > 0) {
+              setSelectionBbox(strokes.at(0).getBBox());
+          }
+          //if (ras)          
+          //setSelectionBbox(TRectD(0.0 - ras.getPointer()->getLx() / 2,
+          //    0.0 - ras.getPointer()->getLy() / 2, ras.getPointer()->getLx() / 2,
+          //    ras.getPointer()->getLy() / 2));
+      }
   }
 
   if (!riData) return;

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -1042,8 +1042,6 @@ void RasterSelection::pasteFloatingSelection() {
   pasteFloatingSelectionWithoutUndo(m_currentImage, m_floatingSelection,
                                     m_affine, wRect, m_noAntialiasing);
 
-  TXshSimpleLevel* sl = m_currentImageCell.getSimpleLevel();
-  TFrameId id = m_currentImageCell.getFrameId();
   ToolUtils::updateSaveBox(m_currentImageCell.getSimpleLevel(),
                            m_currentImageCell.getFrameId());
 
@@ -1252,32 +1250,6 @@ void RasterSelection::pasteSelection() {
                             clipImage.height() / 2));
 
     riData = qimageData;
-  }
-
-  if (m_fromCellSelection && riData) {
-      m_fromCellSelection = false;
-      std::vector<TRectD> rect;
-      double currentDpiX, currentDpiY;
-      double dpiX, dpiY;
-      std::vector<TStroke> strokes;
-      std::vector<TStroke> originalStrokes;
-      TAffine affine;
-      const FullColorImageData* fullColorData =
-          dynamic_cast<const FullColorImageData*>(riData);
-
-      if (TRasterImageP ri = (TRasterImageP)m_currentImage) {
-          ri->getDpi(currentDpiX, currentDpiY);
-          TRasterP ras;
-          riData->getData(ras, dpiX, dpiY, rect, strokes, originalStrokes,
-              affine, ri->getPalette());
-          if (strokes.size() > 0) {
-              setSelectionBbox(strokes.at(0).getBBox());
-          }
-          //if (ras)          
-          //setSelectionBbox(TRectD(0.0 - ras.getPointer()->getLx() / 2,
-          //    0.0 - ras.getPointer()->getLy() / 2, ras.getPointer()->getLx() / 2,
-          //    ras.getPointer()->getLy() / 2));
-      }
   }
 
   if (!riData) return;

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -1196,7 +1196,8 @@ void RasterSelection::pasteSelection() {
   if (isFloating()) pasteFloatingSelection();
   selectNone();
   m_isPastedSelection = true;
-  m_oldPalette        = m_currentImage->getPalette()->clone();
+  if (m_currentImage->getPalette())
+    m_oldPalette = m_currentImage->getPalette()->clone();
   if (stData) {
     if (TToonzImageP ti = m_currentImage)
       riData = stData->toToonzImageData(ti);

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -28,6 +28,7 @@
 #include "toonz/tframehandle.h"
 #include "toonz/txsheethandle.h"
 #include "toonz/tstageobject.h"
+#include "toonzqt/gutil.h"
 
 #include <QApplication>
 #include <QClipboard>
@@ -1190,7 +1191,8 @@ void RasterSelection::pasteSelection() {
       dynamic_cast<const RasterImageData *>(clipboard->mimeData());
   const StrokesData *stData =
       dynamic_cast<const StrokesData *>(clipboard->mimeData());
-  if (!riData && !stData) return;
+  QImage clipImage = clipboard->image();
+  if (!riData && !stData && clipImage.height() == 0) return;
   if (isFloating()) pasteFloatingSelection();
   selectNone();
   m_isPastedSelection = true;
@@ -1212,6 +1214,37 @@ void RasterSelection::pasteSelection() {
       }
       riData = stData->toFullColorImageData(ri);
     }
+  }
+
+  if (clipImage.height() > 0) {
+      std::vector<TRectD> rects;
+      const std::vector<TStroke> strokes;
+      const std::vector<TStroke> originalStrokes;
+      TRasterImageP ri = m_currentImage;
+      TAffine aff;
+      TRasterP ras = rasterFromQImage(clipImage);
+      rects.push_back(TRectD(0.0 - clipImage.width() / 2, 0.0 - clipImage.height() / 2, clipImage.width() / 2, clipImage.height() /2));
+      
+      TRectD r = TRectD(0.0, 0.0, clipImage.width(), clipImage.height());
+      TRect box = getRaster(m_currentImage)->getBounds();
+      r *= convertRasterToWorld(box, m_currentImage);
+      if (!r.isEmpty()) {
+          TStroke stroke = getStrokeByRect(r);
+          if ((int)stroke.getControlPointCount() == 0) return;
+          m_strokes.push_back(stroke);
+          m_originalStrokes.push_back(stroke);
+      }
+
+      
+      FullColorImageData* qimageData = new FullColorImageData();
+
+      qimageData->setData(ras, ri->getPalette(), 120.0, 120.0, ri->getRaster()->getSize(),
+          rects, m_strokes, m_originalStrokes, aff);
+      setSelectionBbox(TRectD(0.0 - clipImage.width() / 2, 0.0 - clipImage.height() / 2, clipImage.width() / 2, clipImage.height() / 2));
+
+
+
+      riData = qimageData;
   }
 
   if (!riData) return;

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -1218,12 +1218,16 @@ void RasterSelection::pasteSelection() {
   }
 
   if (clipImage.height() > 0) {
+    // An image was pasted from outside Tahoma
+
+    // Set up variables
     std::vector<TRectD> rects;
     const std::vector<TStroke> strokes;
     const std::vector<TStroke> originalStrokes;
     TRasterImageP ri = m_currentImage;
     TAffine aff;
     TRasterP ras = rasterFromQImage(clipImage);
+    // center the image in the viewer
     rects.push_back(TRectD(0.0 - clipImage.width() / 2,
                            0.0 - clipImage.height() / 2, clipImage.width() / 2,
                            clipImage.height() / 2));
@@ -1239,7 +1243,7 @@ void RasterSelection::pasteSelection() {
       m_strokes.push_back(stroke);
       m_originalStrokes.push_back(stroke);
     }
-
+    // pack up the data to send to the next pasteSelection
     FullColorImageData *qimageData = new FullColorImageData();
 
     qimageData->setData(ras, ri->getPalette(), 120.0, 120.0,

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -1217,34 +1217,38 @@ void RasterSelection::pasteSelection() {
   }
 
   if (clipImage.height() > 0) {
-      std::vector<TRectD> rects;
-      const std::vector<TStroke> strokes;
-      const std::vector<TStroke> originalStrokes;
-      TRasterImageP ri = m_currentImage;
-      TAffine aff;
-      TRasterP ras = rasterFromQImage(clipImage);
-      rects.push_back(TRectD(0.0 - clipImage.width() / 2, 0.0 - clipImage.height() / 2, clipImage.width() / 2, clipImage.height() /2));
-      
-      TRectD r = TRectD(0.0, 0.0, clipImage.width(), clipImage.height());
-      TRect box = getRaster(m_currentImage)->getBounds();
-      r *= convertRasterToWorld(box, m_currentImage);
-      if (!r.isEmpty()) {
-          TStroke stroke = getStrokeByRect(r);
-          if ((int)stroke.getControlPointCount() == 0) return;
-          m_strokes.push_back(stroke);
-          m_originalStrokes.push_back(stroke);
-      }
+    std::vector<TRectD> rects;
+    const std::vector<TStroke> strokes;
+    const std::vector<TStroke> originalStrokes;
+    TRasterImageP ri = m_currentImage;
+    TAffine aff;
+    TRasterP ras = rasterFromQImage(clipImage);
+    rects.push_back(TRectD(0.0 - clipImage.width() / 2,
+                           0.0 - clipImage.height() / 2, clipImage.width() / 2,
+                           clipImage.height() / 2));
 
-      
-      FullColorImageData* qimageData = new FullColorImageData();
+    TRectD r =
+        TRectD(0.0 - (clipImage.width() / 2), 0.0 - (clipImage.height() / 2),
+               clipImage.width() / 2, clipImage.height() / 2);
+    TRect box = getRaster(m_currentImage)->getBounds();
+    r *= convertRasterToWorld(box, m_currentImage);
+    if (!r.isEmpty()) {
+      TStroke stroke = getStrokeByRect(r);
+      if ((int)stroke.getControlPointCount() == 0) return;
+      m_strokes.push_back(stroke);
+      m_originalStrokes.push_back(stroke);
+    }
 
-      qimageData->setData(ras, ri->getPalette(), 120.0, 120.0, ri->getRaster()->getSize(),
-          rects, m_strokes, m_originalStrokes, aff);
-      setSelectionBbox(TRectD(0.0 - clipImage.width() / 2, 0.0 - clipImage.height() / 2, clipImage.width() / 2, clipImage.height() / 2));
+    FullColorImageData *qimageData = new FullColorImageData();
 
+    qimageData->setData(ras, ri->getPalette(), 120.0, 120.0,
+                        ri->getRaster()->getSize(), rects, m_strokes,
+                        m_originalStrokes, aff);
+    setSelectionBbox(TRectD(0.0 - clipImage.width() / 2,
+                            0.0 - clipImage.height() / 2, clipImage.width() / 2,
+                            clipImage.height() / 2));
 
-
-      riData = qimageData;
+    riData = qimageData;
   }
 
   if (!riData) return;

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -533,12 +533,14 @@ void ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded() const {
     m_level->eraseFrame(m_frameId);
     if (!m_isEditingLevel) {
       TXsheet *xsh = app->getCurrentXsheet()->getXsheet();
+      TXshCell cell;
       for (const TTool::CellOps &cellOps : m_cellsData) {
-        TXshCell cell;
         if (cellOps.type == TTool::CellOps::ExistingToNew)
           cell = xsh->getCell(cellOps.r0 - 1, m_col);
         for (int r = cellOps.r0; r <= cellOps.r1; r++)
           xsh->setCell(r, m_col, cell);
+      } if (m_cellsData.size() < 1) {
+          xsh->setCell(m_row, m_col, cell);
       }
     }
     if (m_createdLevel) {

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -707,8 +707,7 @@ void ToolUtils::TFullColorRasterUndo::undo() const {
 
   removeLevelAndFrameIfNeeded();
   if (m_level) {
-      m_level->setDirtyFlag(true);
-      //app->getCurrentLevel()->notifyLevelChange();
+    m_level->setDirtyFlag(true);
   }
   app->getCurrentXsheet()->notifyXsheetChanged();
   notifyImageChanged();

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -539,8 +539,9 @@ void ToolUtils::TToolUndo::removeLevelAndFrameIfNeeded() const {
           cell = xsh->getCell(cellOps.r0 - 1, m_col);
         for (int r = cellOps.r0; r <= cellOps.r1; r++)
           xsh->setCell(r, m_col, cell);
-      } if (m_cellsData.size() < 1) {
-          xsh->setCell(m_row, m_col, cell);
+      }
+      if (m_cellsData.size() < 1) {
+        xsh->setCell(m_row, m_col, cell);
       }
     }
     if (m_createdLevel) {

--- a/toonz/sources/tnztools/toolutils.cpp
+++ b/toonz/sources/tnztools/toolutils.cpp
@@ -706,7 +706,10 @@ void ToolUtils::TFullColorRasterUndo::undo() const {
   }
 
   removeLevelAndFrameIfNeeded();
-
+  if (m_level) {
+      m_level->setDirtyFlag(true);
+      //app->getCurrentLevel()->notifyLevelChange();
+  }
   app->getCurrentXsheet()->notifyXsheetChanged();
   notifyImageChanged();
 }

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1967,7 +1967,7 @@ void TCellSelection::pasteCells() {
             // New level chosen
 
             // find the next empty column
-            while (!xsh->getCell(r0, c0).isEmpty()) {
+            while (!xsh->isColumnEmpty(c0)) {
               c0 += 1;
             }
             TXshColumn *col =

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -1710,7 +1710,7 @@ static void pasteRasterImageInCell(int row, int col,
   } else if (fullColorTiles) {
     TUndoManager::manager()->add(new PasteFullColorImageInCellsUndo(
         rasterImageData, fullColorTiles, cell.getSimpleLevel(),
-        cell.getFrameId(), oldPalette, createdFrame, isLevelCreated));
+        cell.getFrameId(), oldPalette, createdFrame, isLevelCreated, col));
   }
 }
 
@@ -1951,7 +1951,18 @@ void TCellSelection::pasteCells() {
             if (initUndo) TUndoManager::manager()->endBlock();
             return;
           }
-          if (ret == 2) newLevel = true;
+          if (ret == 2) {
+              if (newLevel) {
+                  while (!xsh->getCell(r0, c0).isEmpty()) {
+                      c0 += 1;
+                      TXshColumn* col = TApp::instance()->getCurrentXsheet()->getXsheet()->getColumn(c0);
+                      TApp::instance()->getCurrentColumn()->setColumnIndex(c0);
+                      TApp::instance()->getCurrentColumn()->setColumn(col);
+                      TApp::instance()->getCurrentFrame()->setFrame(r0);
+                  }
+              }
+              newLevel = true;
+          }
         }
 
         std::vector<TRectD> rects;
@@ -1979,21 +1990,32 @@ void TCellSelection::pasteCells() {
                             originalStrokes, aff);
         rasterImageData = qimageData;
       }
-      ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
-      if (sl && toolHandle->getTool()->getName() == "T_Selection") {
-        TSelection *ts      = toolHandle->getTool()->getSelection();
-        RasterSelection *rs = dynamic_cast<RasterSelection *>(ts);
-        rs->setCurrentImageCell(xsh->getCell(r0, c0));
-        if (rs)
-          rs->pasteSelection(rasterImageData);
-        else {
-          if (!initUndo) {
-            initUndo = true;
-            TUndoManager::manager()->beginBlock();
-          }
-          pasteRasterImageInCell(r0, c0, rasterImageData, newLevel);
-        }
-      } else {
+      //ToolHandle *toolHandle = TApp::instance()->getCurrentTool();
+      //TXshCell currentCell = xsh->getCell(r0, c0);
+      //if (false && !currentCell.isEmpty() && sl && toolHandle->getTool()->getName() == "T_Selection") {
+      //  TSelection *ts      = toolHandle->getTool()->getSelection();
+      //  RasterSelection *rs = dynamic_cast<RasterSelection *>(ts);
+      //  if (rs) {
+      //      if (clipImage.height() > 0) {
+      //          rs->setCurrentImage(xsh->getCell(r0, c0).getImage(true), xsh->getCell(r0, c0));
+      //          rs->pasteSelection(rasterImageData);
+      //      }
+      //      else {
+      //          rs->setIncoming();
+      //          rs->setCurrentImage(xsh->getCell(r0, c0).getImage(true), xsh->getCell(r0, c0));
+      //          rs->pasteSelection();
+      //      }
+      //      return;
+      //  }
+      //  else {
+      //    if (!initUndo) {
+      //      initUndo = true;
+      //      TUndoManager::manager()->beginBlock();
+      //    }
+      //    pasteRasterImageInCell(r0, c0, rasterImageData, newLevel);
+      //  }
+      //} else 
+      {
         if (!initUndo) {
           initUndo = true;
           TUndoManager::manager()->beginBlock();

--- a/toonz/sources/toonz/cellselection.cpp
+++ b/toonz/sources/toonz/cellselection.cpp
@@ -246,7 +246,7 @@ public:
     int r0, c0, r1, c1;
     selection->getSelectedCells(r0, c0, r1, c1);
     if (c0 < 0) c0 = 0;  // Ignore camera column
-    m_selection = new TCellSelection();
+    m_selection    = new TCellSelection();
     m_selection->selectCells(r0, c0, r1, c1);
 
     TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
@@ -334,7 +334,7 @@ public:
     int r0, c0, r1, c1;
     selection->getSelectedCells(r0, c0, r1, c1);
     if (c0 < 0) c0 = 0;  // Ignore camera column
-    m_selection = new TCellSelection();
+    m_selection    = new TCellSelection();
     m_selection->selectCells(r0, c0, r1, c1);
 
     TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
@@ -474,7 +474,7 @@ bool pasteStrokesInCellWithoutUndo(
   TFrameId fid(1);
   if (cell.isEmpty()) {
     if (row > 0) cell = xsh->getCell(row - 1, col);
-    sl = cell.getSimpleLevel();
+    sl                = cell.getSimpleLevel();
     if (!sl || sl->getType() != PLI_XSHLEVEL) {
       ToonzScene *scene = app->getCurrentScene()->getScene();
       TXshLevel *xl     = scene->createNewLevel(PLI_XSHLEVEL);
@@ -561,7 +561,7 @@ public:
       else
         oldPalette = xsh->getCell(row - 1, col).getSimpleLevel()->getPalette();
     } else
-      oldPalette = cell.getSimpleLevel()->getPalette();
+      oldPalette                 = cell.getSimpleLevel()->getPalette();
     if (oldPalette) m_oldPalette = oldPalette->clone();
   }
 
@@ -644,14 +644,14 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
   TCamera *camera   = scene->getCurrentCamera();
   if (cell.isEmpty()) {
     if (row > 0) cell = xsh->getCell(row - 1, col);
-    sl = cell.getSimpleLevel();
+    sl                = cell.getSimpleLevel();
     if (!sl || (sl->getType() == OVL_XSHLEVEL &&
                 sl->getPath().getFrame() == TFrameId::NO_FRAME)) {
       int levelType;
       if (dynamic_cast<const ToonzImageData *>(rasterImageData))
         levelType = TZP_XSHLEVEL;
       else if (dynamic_cast<const FullColorImageData *>(rasterImageData))
-        levelType = OVL_XSHLEVEL;
+        levelType   = OVL_XSHLEVEL;
       TXshLevel *xl = 0;
       if (levelType == TZP_XSHLEVEL)
         xl = scene->createNewLevel(TZP_XSHLEVEL, L"", rasterImageData->getDim(),
@@ -668,7 +668,7 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
                 levelType);
         if (defaultPalette) sl->setPalette(defaultPalette->clone());
       }
-	  assert(sl);
+      assert(sl);
       app->getCurrentScene()->notifyCastChange();
 
       if (levelType == TZP_XSHLEVEL || levelType == OVL_XSHLEVEL) {
@@ -699,6 +699,13 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
     }
   }
   if (img) {
+    // This seems redundant, but newly created levels were having an issue with
+    // pasting.
+    // Don't know why.
+    cell = xsh->getCell(row, col);
+    sl   = cell.getSimpleLevel();
+    fid  = cell.getFrameId();
+    img  = cell.getImage(true);
     TRasterP ras;
     TRasterP outRas;
     double imgDpiX, imgDpiY;
@@ -731,11 +738,11 @@ bool pasteRasterImageInCellWithoutUndo(int row, int col,
     affine *= sc;
     int i;
     TRectD boxD;
-    if (rects.size() > 0) boxD = rects[0];
+    if (rects.size() > 0) boxD   = rects[0];
     if (strokes.size() > 0) boxD = strokes[0].getBBox();
     for (i = 0; i < rects.size(); i++) boxD += rects[i];
     for (i = 0; i < strokes.size(); i++) boxD += strokes[i].getBBox();
-    boxD = affine * boxD;
+    boxD   = affine * boxD;
     TPoint pos;
     if (sl->getType() == TZP_XSHLEVEL) {
       TRect box = ToonzImageUtils::convertWorldToRaster(boxD, img);
@@ -814,10 +821,12 @@ public:
                                  TTileSetFullColor *tiles,
                                  TXshSimpleLevel *level, const TFrameId &id,
                                  TPaletteP oldPalette, bool createdFrame,
-                                 bool isLevelCreated)
+                                 bool isLevelCreated, int col = -1)
       : ToolUtils::TFullColorRasterUndo(tiles, level, id, createdFrame,
                                         isLevelCreated, oldPalette)
-      , m_rasterImageData(data->clone()) {}
+      , m_rasterImageData(data->clone()) {
+    if (col > 0) m_col = col;
+  }
 
   ~PasteFullColorImageInCellsUndo() { delete m_rasterImageData; }
   void redo() const override {
@@ -1649,27 +1658,43 @@ static void pasteStrokesInCell(int row, int col,
 //-----------------------------------------------------------------------------
 
 static void pasteRasterImageInCell(int row, int col,
-                                   const RasterImageData *rasterImageData) {
-  TXsheet *xsh         = TApp::instance()->getCurrentXsheet()->getXsheet();
-  TXshCell cell        = xsh->getCell(row, col);
+                                   const RasterImageData *rasterImageData,
+                                   bool newLevel = false) {
+  TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+
   bool createdFrame    = false;
   bool isLevelCreated  = false;
   TPaletteP oldPalette = 0;
-  if (!cell.getSimpleLevel()) {
-    createdFrame        = true;
-    TXshSimpleLevel *sl = xsh->getCell(row - 1, col).getSimpleLevel();
-    if (sl) oldPalette = sl->getPalette();
-  } else {
-    TXshSimpleLevel *sl = cell.getSimpleLevel();
-    if (sl->getType() == OVL_XSHLEVEL &&
-        (sl->getPath().getType() == "psd" || sl->getPath().getType() == "gif" ||
-         sl->getPath().getType() == "mp4" || sl->getPath().getType() == "webm"))
-      return;
-    oldPalette = sl->getPalette();
+
+  if (newLevel) {
+    while (!xsh->getCell(row, col).isEmpty()) {
+      col += 1;
+    }
+    createdFrame = true;
+  }
+  // get the current cell
+  TXshCell cell = xsh->getCell(row, col);
+  // if the cell doesn't have a level. . .
+  if (!newLevel) {
+    if (!cell.getSimpleLevel()) {
+      createdFrame = true;
+      // try the previous frame
+      TXshSimpleLevel *sl = xsh->getCell(row - 1, col).getSimpleLevel();
+      if (sl) oldPalette  = sl->getPalette();
+    } else {
+      TXshSimpleLevel *sl = cell.getSimpleLevel();
+      // don't do anything to ffmpeg level types
+      if (sl->getType() == OVL_XSHLEVEL && (sl->getPath().getType() == "psd" ||
+                                            sl->getPath().getType() == "gif" ||
+                                            sl->getPath().getType() == "mp4" ||
+                                            sl->getPath().getType() == "webm"))
+        return;
+      oldPalette = sl->getPalette();
+    }
   }
   if (oldPalette) oldPalette = oldPalette->clone();
-  TTileSet *tiles = 0;
-  bool isPaste    = pasteRasterImageInCellWithoutUndo(row, col, rasterImageData,
+  TTileSet *tiles            = 0;
+  bool isPaste = pasteRasterImageInCellWithoutUndo(row, col, rasterImageData,
                                                    &tiles, isLevelCreated);
   if (isLevelCreated && oldPalette.getPointer()) oldPalette = 0;
   if (!isPaste) return;
@@ -1777,8 +1802,9 @@ void TCellSelection::pasteCells() {
       return;
     }
     TKeyframeSelection selection;
-    if (isEmpty() && TApp::instance()->getCurrentObject()->getObjectId() ==
-                         TStageObjectId::CameraId(xsh->getCameraColumnIndex()))
+    if (isEmpty() &&
+        TApp::instance()->getCurrentObject()->getObjectId() ==
+            TStageObjectId::CameraId(xsh->getCameraColumnIndex()))
     // Se la selezione e' vuota e l'objectId e' quello della camera sono nella
     // colonna di camera quindi devo selezionare la row corrente e -1.
     {
@@ -1869,10 +1895,9 @@ void TCellSelection::pasteCells() {
   }
 
   QImage clipImage = clipboard->image();
-  
 
-  const RasterImageData* rasterImageData =
-      dynamic_cast<const RasterImageData*>(mimeData);
+  const RasterImageData *rasterImageData =
+      dynamic_cast<const RasterImageData *>(mimeData);
   if (rasterImageData || clipImage.height() > 0) {
     if (isEmpty())  // Se la selezione delle celle e' vuota ritorno.
       return;
@@ -1895,35 +1920,65 @@ void TCellSelection::pasteCells() {
       return;
     }
     if (!initUndo) {
-        initUndo = true;
-        TUndoManager::manager()->beginBlock();
+      initUndo = true;
+      TUndoManager::manager()->beginBlock();
     }
     if (vi) {
       TXshSimpleLevel *sl = xsh->getCell(r0, c0).getSimpleLevel();
-      if (!sl) sl = xsh->getCell(r0 - 1, c0).getSimpleLevel();
+      if (!sl) sl         = xsh->getCell(r0 - 1, c0).getSimpleLevel();
       assert(sl);
       StrokesData *strokesData = rasterImageData->toStrokesData(sl->getScene());
       pasteStrokesInCell(r0, c0, strokesData);
-    }
-    else {
-        TRasterImageP ri(img);
-        TXshSimpleLevel* sl = xsh->getCell(r0, c0).getSimpleLevel();
-        if (!sl) sl = xsh->getCell(r0 - 1, c0).getSimpleLevel();
-        assert(sl);
-        if (clipImage.height() > 0) {
-            std::vector<TRectD> rects;
-            const std::vector<TStroke> strokes;
-            const std::vector<TStroke> originalStrokes;
-            TAffine aff;
-            TRasterP ras = rasterFromQImage(clipImage);
-            rects.push_back(TRectD(0.0 - clipImage.width() / 2, 0.0 - clipImage.height() / 2, clipImage.width(), clipImage.height()));
-            FullColorImageData* qimageData = new FullColorImageData();
-            qimageData->setData(ras, ri->getPalette(), 120.0, 120.0, ri->getRaster()->getSize(),
-                rects, strokes, originalStrokes, aff);
-            rasterImageData = qimageData;
+    } else {
+      TXshSimpleLevel *sl = xsh->getCell(r0, c0).getSimpleLevel();
+      if (!sl) sl         = xsh->getCell(r0 - 1, c0).getSimpleLevel();
+      bool newLevel       = false;
+      TRasterImageP ri(img);
+      if (clipImage.height() > 0) {
+        bool tooBig = false;
+        if (sl && (sl->getResolution().lx < clipImage.width() ||
+                   sl->getResolution().ly < clipImage.height())) {
+          tooBig           = true;
+          QString question = QObject::tr(
+              "The pasted image is larger than the current level.\nPasting in "
+              "the level will crop some of the image.\nWhat do you want to "
+              "do?");
+          int ret = DVGui::MsgBox(question, QObject::tr("Paste in place"),
+                                  QObject::tr("Create a new level."),
+                                  QObject::tr("Cancel"), 1);
+          if (ret == 3 || ret == 0) {
+            if (initUndo) TUndoManager::manager()->endBlock();
+            return;
+          }
+          if (ret == 2) newLevel = true;
         }
-        pasteRasterImageInCell(r0, c0, rasterImageData);
-        sl->setDirtyFlag(true);
+
+        std::vector<TRectD> rects;
+        const std::vector<TStroke> strokes;
+        const std::vector<TStroke> originalStrokes;
+        TAffine aff;
+        TRasterP ras = rasterFromQImage(clipImage);
+        rects.push_back(TRectD(0.0 - clipImage.width() / 2,
+                               0.0 - clipImage.height() / 2,
+                               clipImage.width() / 2, clipImage.height() / 2));
+        FullColorImageData *qimageData = new FullColorImageData();
+        TPalette *p;
+        if (!ri)
+          p = TApp::instance()->getPaletteController()->getDefaultPalette(
+              OVL_XSHLEVEL);
+        else
+          p = ri->getPalette();
+        TDimension dim;
+        if (ri && !newLevel) {
+          dim = ri->getRaster()->getSize();
+        } else {
+          dim = TDimension(clipImage.width(), clipImage.height());
+        }
+        qimageData->setData(ras, p, 120.0, 120.0, dim, rects, strokes,
+                            originalStrokes, aff);
+        rasterImageData = qimageData;
+      }
+      pasteRasterImageInCell(r0, c0, rasterImageData, newLevel);
     }
   }
   if (!initUndo) {
@@ -2043,11 +2098,11 @@ void TCellSelection::pasteDuplicateCells() {
           DVGui::warning(
               QObject::tr("Cannot duplicate frames in read only levels"));
           return;
-        }
-        else if (level->getSimpleLevel() && it->getFrameId() == TFrameId::NO_FRAME) {
-            DVGui::warning(
-                QObject::tr("Can only duplicate frames in image sequence levels."));
-            return;
+        } else if (level->getSimpleLevel() &&
+                   it->getFrameId() == TFrameId::NO_FRAME) {
+          DVGui::warning(QObject::tr(
+              "Can only duplicate frames in image sequence levels."));
+          return;
         }
       }
       it++;
@@ -2264,7 +2319,7 @@ void TCellSelection::deleteCells() {
   int r0, c0, r1, c1;
   getSelectedCells(r0, c0, r1, c1);
   if (c0 < 0) c0 = 0;  // Ignore camera column
-  TXsheet *xsh = TApp::instance()->getCurrentXsheet()->getXsheet();
+  TXsheet *xsh   = TApp::instance()->getCurrentXsheet()->getXsheet();
   // if all the selected cells are already empty, then do nothing
   if (xsh->isRectEmpty(CellPosition(r0, c0), CellPosition(r1, c1))) return;
   TCellData *data = new TCellData();
@@ -2335,8 +2390,9 @@ void TCellSelection::pasteKeyframesInto() {
     getSelectedCells(r0, c0, r1, c1);
 
     TKeyframeSelection selection;
-    if (isEmpty() && TApp::instance()->getCurrentObject()->getObjectId() ==
-                         TStageObjectId::CameraId(xsh->getCameraColumnIndex()))
+    if (isEmpty() &&
+        TApp::instance()->getCurrentObject()->getObjectId() ==
+            TStageObjectId::CameraId(xsh->getCameraColumnIndex()))
     // Se la selezione e' vuota e l'objectId e' quello della camera sono nella
     // colonna di camera quindi devo selezionare la row corrente e -1.
     {
@@ -2743,8 +2799,8 @@ public:
     m_oldCell = getXsheet()->getCell(m_row, m_col);
   }
   void onAdd() override {
-    m_newCell   = getXsheet()->getCell(m_row, m_col);
-    TImageP img = m_newCell.getImage(false);
+    m_newCell      = getXsheet()->getCell(m_row, m_col);
+    TImageP img    = m_newCell.getImage(false);
     if (img) m_img = img->cloneImage();
   }
   TXsheet *getXsheet() const {
@@ -3092,7 +3148,7 @@ void TCellSelection::overwritePasteNumbers() {
     // store celldata for undo
     r1 = r0 + cellData->getRowCount() - 1;
     if (cellData->getColCount() != 1 || c0 == c1)
-      c1 = c0 + cellData->getColCount() - 1;
+      c1                  = c0 + cellData->getColCount() - 1;
     TCellData *beforeData = new TCellData();
     beforeData->setCells(xsh, r0, c0, r1, c1);
 

--- a/toonz/sources/toonz/sceneviewer.cpp
+++ b/toonz/sources/toonz/sceneviewer.cpp
@@ -1596,18 +1596,18 @@ void SceneViewer::drawOverlay() {
         m_pixelSize = sqrt(tglGetPixelSize2()) * getDevPixRatio();
         ViewerDraw::drawCamera(f, m_pixelSize);
         glPopMatrix();
-        if (fieldGuideToggle.getStatus()) {
-            glPushMatrix();
-            tglMultMatrix(m_drawCameraAff);
-            ViewerDraw::drawCameraOverlays(this, f, m_pixelSize);
-            glPopMatrix();
-          glPushMatrix();
-          tglMultMatrix(m_drawTableAff);
-          if (ViewerDraw::getShowFieldGuide()) ViewerDraw::drawFieldGuide();
-          ViewerDraw::drawGridsAndOverlays(this, f, m_pixelSize);
-          glPopMatrix();
-        }
       }
+    }
+    if (fieldGuideToggle.getStatus()) {
+      glPushMatrix();
+      tglMultMatrix(m_drawCameraAff);
+      ViewerDraw::drawCameraOverlays(this, m_pixelSize);
+      glPopMatrix();
+      glPushMatrix();
+      tglMultMatrix(m_drawTableAff);
+      if (ViewerDraw::getShowFieldGuide()) ViewerDraw::drawFieldGuide();
+      ViewerDraw::drawGridsAndOverlays(this, m_pixelSize);
+      glPopMatrix();
     }
 
 #ifdef WITH_CANON

--- a/toonz/sources/toonz/viewerdraw.cpp
+++ b/toonz/sources/toonz/viewerdraw.cpp
@@ -672,8 +672,7 @@ void ViewerDraw::drawSafeArea() {
 
 //-----------------------------------------------------------------------------
 
-void ViewerDraw::drawGridsAndOverlays(SceneViewer *viewer, unsigned long flags,
-                                      double pixelSize) {
+void ViewerDraw::drawGridsAndOverlays(SceneViewer *viewer, double pixelSize) {
   TRectD rect = getCameraRect();
 
   int x1, x2, y1, y2;
@@ -851,8 +850,7 @@ void ViewerDraw::drawGridsAndOverlays(SceneViewer *viewer, unsigned long flags,
 
 //-----------------------------------------------------------------------------
 
-void ViewerDraw::drawCameraOverlays(SceneViewer *viewer, unsigned long flags,
-                                    double pixelSize) {
+void ViewerDraw::drawCameraOverlays(SceneViewer *viewer, double pixelSize) {
   TRectD rect = getCameraRect();
 
   glEnable(GL_BLEND);  // Enable blending.

--- a/toonz/sources/toonz/viewerdraw.h
+++ b/toonz/sources/toonz/viewerdraw.h
@@ -40,10 +40,8 @@ void drawPerspectiveGuides(SceneViewer *viewer, double viewerScale,
 
 void draw3DCamera(unsigned long flags, double zmin, double phi);
 void drawCamera(unsigned long flags, double pixelSize);
-void drawGridsAndOverlays(SceneViewer *viewer, unsigned long flags,
-                          double pixelSize);
-void drawCameraOverlays(SceneViewer* viewer, unsigned long flags,
-    double pixelSize);
+void drawGridsAndOverlays(SceneViewer *viewer, double pixelSize);
+void drawCameraOverlays(SceneViewer *viewer, double pixelSize);
 void draw3DFrame(double zmin, double phi);
 void drawDisk(int &tableDLId);
 void drawFieldGuide();


### PR DESCRIPTION
This enables the pasting of outside images into Tahoma.

More to do.

Workflow:
Select the frame you want it pasted to, and paste.
If on the selection tool, you will get the transform tools.

This is still WIP so tweaking to workflow and ease of use is still being done.  Undo currently is borked in a few cases.