### PR TITLE
Add current project to File Browser

### DIFF
--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -351,6 +351,7 @@ DvDirTreeView::DvDirTreeView(QWidget *parent)
 
   ret = ret && connect(dynamic_cast<DvDirModel *>(this->model()),
                        &DvDirModel::projectAdded, [=]() {
+                         collapseAll();
                          setCurrentNode(TProjectManager::instance()
                                             ->getCurrentProjectPath()
                                             .getParentDir(),

--- a/toonz/sources/toonz/dvdirtreeview.cpp
+++ b/toonz/sources/toonz/dvdirtreeview.cpp
@@ -349,6 +349,14 @@ DvDirTreeView::DvDirTreeView(QWidget *parent)
   ret = ret && connect(this->model(), SIGNAL(layoutChanged()), this,
                        SLOT(resizeToConts()));
 
+  ret = ret && connect(dynamic_cast<DvDirModel *>(this->model()),
+                       &DvDirModel::projectAdded, [=]() {
+                         setCurrentNode(TProjectManager::instance()
+                                            ->getCurrentProjectPath()
+                                            .getParentDir(),
+                                        true);
+                       });
+
   if (Preferences::instance()->isWatchFileSystemEnabled()) {
     ret = ret && connect(this, SIGNAL(expanded(const QModelIndex &)), this,
                          SLOT(onExpanded(const QModelIndex &)));

--- a/toonz/sources/toonz/filebrowsermodel.h
+++ b/toonz/sources/toonz/filebrowsermodel.h
@@ -310,6 +310,8 @@ class DvDirModelRootNode final : public DvDirModelNode {
   DvDirModelMyComputerNode *m_myComputerNode;
   DvDirModelNetworkNode *m_networkNode;
   DvDirModelProjectNode *m_sandboxProjectNode;
+  DvDirModelProjectNode *m_currentProjectNode;
+  std::set<TFilePath> m_projectPaths;
   DvDirModelSceneFolderNode *m_sceneFolderNode;
   std::vector<DvDirModelSpecialFileFolderNode *> m_specialNodes;
 

--- a/toonz/sources/toonz/filebrowsermodel.h
+++ b/toonz/sources/toonz/filebrowsermodel.h
@@ -320,6 +320,7 @@ class DvDirModelRootNode final : public DvDirModelNode {
 public:
   DvDirModelRootNode();
   void refreshChildren() override;
+  int getProjectPathsSize() { return m_projectPaths.size(); }
 
   DvDirModelNode *getNodeByPath(const TFilePath &path) override;
   // QPixmap getPixmap(bool isOpen) const;
@@ -383,6 +384,8 @@ public:
     emit beginInsertRows(parent, first, last);
   }
   void notifyEndInsertRows() { emit endInsertRows(); }
+signals:
+  void projectAdded();
 
 protected slots:
   // when the scene switched, update the path of the scene location node


### PR DESCRIPTION
This adds the current project to the file browser.  If projects are switched, it will append the new project to the end of the list.  Upon restarting, only the current project populates the list.