### PR TITLE
Fix RGB picker offset

### DIFF
--- a/toonz/sources/tnztools/rgbpickertool.cpp
+++ b/toonz/sources/tnztools/rgbpickertool.cpp
@@ -524,12 +524,6 @@ void RGBPickerTool::pickStroke() {
     TXshSimpleLevel *level = app->getCurrentLevel()->getSimpleLevel();
     TUndoManager::manager()->add(
         new UndoPickRGBM(palette, styleId, m_currentValue, level));
-    // setCurrentColor(m_currentValue);
-    // if (level) {
-    //  std::vector<TFrameId> fids;
-    //  level->getFids(fids);
-    //  invalidateIcons(level, fids);
-    //}
   }
 }
 

--- a/toonz/sources/tnztools/rgbpickertool.cpp
+++ b/toonz/sources/tnztools/rgbpickertool.cpp
@@ -91,6 +91,13 @@ public:
     } else {
       controller->setColorSample(color);
     }
+    TTool::Application *app = TTool::getApplication();
+    TXshSimpleLevel *level  = app->getCurrentLevel()->getSimpleLevel();
+    if (level) {
+      std::vector<TFrameId> fids;
+      level->getFids(fids);
+      invalidateIcons(level, fids);
+    }
   }
 
   void undo() const override { setColor(m_oldValue); }
@@ -236,17 +243,19 @@ void RGBPickerTool::updateTranslation() {
 // another glContext
 
 void RGBPickerTool::onImageChanged() {
+  TTool::Application *app = TTool::getApplication();
+  TXshSimpleLevel *level  = app->getCurrentLevel()->getSimpleLevel();
   if (m_currentStyleId != 0 && m_makePick &&
       (m_pickType.getValue() == POLYLINE_PICK ||
        m_pickType.getValue() == RECT_PICK)) {
-    TTool::Application *app = TTool::getApplication();
-    TPaletteHandle *ph      = app->getPaletteController()->getCurrentPalette();
-    int styleId             = ph->getStyleIndex();
-    TPalette *palette       = ph->getPalette();
-    TXshSimpleLevel *level  = app->getCurrentLevel()->getSimpleLevel();
+    TPaletteHandle *ph = app->getPaletteController()->getCurrentPalette();
+    int styleId        = ph->getStyleIndex();
+    TPalette *palette  = ph->getPalette();
     if (palette)
       TUndoManager::manager()->add(
           new UndoPickRGBM(palette, styleId, m_currentValue, level));
+  }
+  if (m_makePick) {
     setCurrentColor(m_currentValue);
     if (level) {
       std::vector<TFrameId> fids;
@@ -372,7 +381,7 @@ void RGBPickerTool::leftButtonUp(const TPointD &pos, const TMouseEvent &) {
   }
   if (m_pickType.getValue() == FREEHAND_PICK) {
     closeFreehand();
-    if (m_currentStyleId != 0) m_makePick = true;
+    m_makePick = true;
   }
   invalidate();
 }
@@ -460,18 +469,6 @@ void RGBPickerTool::pick() {
   TXshSimpleLevel *level = app->getCurrentLevel()->getSimpleLevel();
   UndoPickRGBM *cmd = new UndoPickRGBM(palette, styleId, m_currentValue, level);
   TUndoManager::manager()->add(cmd);
-  cmd->redo();
-
-  m_makePick = false;
-  /*
-setCurrentColor(m_currentValue);
-if(level)
-{
-vector<TFrameId> fids;
-level->getFids(fids);
-invalidateIcons(level,fids);
-}
-*/
 }
 //---------------------------------------------------------
 
@@ -527,12 +524,12 @@ void RGBPickerTool::pickStroke() {
     TXshSimpleLevel *level = app->getCurrentLevel()->getSimpleLevel();
     TUndoManager::manager()->add(
         new UndoPickRGBM(palette, styleId, m_currentValue, level));
-    setCurrentColor(m_currentValue);
-    if (level) {
-      std::vector<TFrameId> fids;
-      level->getFids(fids);
-      invalidateIcons(level, fids);
-    }
+    // setCurrentColor(m_currentValue);
+    // if (level) {
+    //  std::vector<TFrameId> fids;
+    //  level->getFids(fids);
+    //  invalidateIcons(level, fids);
+    //}
   }
 }
 


### PR DESCRIPTION
closes #219 

All updates to the style need to be called during onImageChanged instead of the actual pick events to avoid OpenGl errors.