### PR TITLE
Ask to use microphone on macOS

### DIFF
--- a/toonz/cmake/BundleInfo.plist.in
+++ b/toonz/cmake/BundleInfo.plist.in
@@ -14,6 +14,8 @@
 	<string>io.github.turtletooth.Tahoma</string>
     <key>NSCameraUsageDescription</key>
     <string>Tahoma needs access to the camera in order to use Camera Capture</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Tahoma needs access to the microphone in order to record audio.</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>


### PR DESCRIPTION
On later versions of macOS, permission needs to be granted by the user in order for Tahoma to access the microphone. This has no impact on the crash from recording audio #158.

https://developer.apple.com/documentation/avfoundation/cameras_and_media_capture/requesting_authorization_for_media_capture_on_macos