### PR TITLE
Fix issues with starting maximized not working

### DIFF
--- a/toonz/sources/toonzqt/docklayout.cpp
+++ b/toonz/sources/toonzqt/docklayout.cpp
@@ -458,43 +458,45 @@ bool Region::checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets,
     return ret;
   }
 }
-
-//------------------------------------------------------
-
-bool Region::checkWidgetsToBeFixedHeight(std::vector<QWidget *> &widgets,
-                                         bool &fromDocking) {
-  if (m_item) {
-    if (m_item->wasFloating()) {
-      fromDocking = true;
-      m_item->clearWasFloating();
-      return false;
-    }
-    if ((m_item->objectName() == "Timeline")) {
-      widgets.push_back(m_item);
-      return true;
-    } else
-      return false;
-  }
-  if (m_childList.empty()) return false;
-  // for vertical orientation, return true if all items are to be fixed
-  if (m_orientation == vertical) {
-    bool ret = true;
-    for (Region *childRegion : m_childList) {
-      if (!childRegion->checkWidgetsToBeFixedHeight(widgets, fromDocking))
-        ret = false;
-    }
-    return ret;
-  }
-  // for horizontal orientation, return true if at least one item is to be fixed
-  else {
-    bool ret = false;
-    for (Region *childRegion : m_childList) {
-      if (childRegion->checkWidgetsToBeFixedHeight(widgets, fromDocking))
-        ret = true;
-    }
-    return ret;
-  }
-}
+// As much as I want this to work.
+// This causes issues on maximize if the timeline is too tall.
+////------------------------------------------------------
+//
+// bool Region::checkWidgetsToBeFixedHeight(std::vector<QWidget *> &widgets,
+//                                         bool &fromDocking) {
+//  if (m_item) {
+//    if (m_item->wasFloating()) {
+//      fromDocking = true;
+//      m_item->clearWasFloating();
+//      return false;
+//    }
+//    if ((m_item->objectName() == "Timeline")) {
+//      widgets.push_back(m_item);
+//      return true;
+//    } else
+//      return false;
+//  }
+//  if (m_childList.empty()) return false;
+//  // for vertical orientation, return true if all items are to be fixed
+//  if (m_orientation == vertical) {
+//    bool ret = true;
+//    for (Region *childRegion : m_childList) {
+//      if (!childRegion->checkWidgetsToBeFixedHeight(widgets, fromDocking))
+//        ret = false;
+//    }
+//    return ret;
+//  }
+//  // for horizontal orientation, return true if at least one item is to be
+//  fixed
+//  else {
+//    bool ret = false;
+//    for (Region *childRegion : m_childList) {
+//      if (childRegion->checkWidgetsToBeFixedHeight(widgets, fromDocking))
+//        ret = true;
+//    }
+//    return ret;
+//  }
+//}
 
 //------------------------------------------------------
 
@@ -514,17 +516,18 @@ void DockLayout::redistribute() {
     bool fromDocking = false;
     bool widgetsCanBeFixedWidth =
         !m_regions.front()->checkWidgetsToBeFixedWidth(widgets, fromDocking);
-    bool widgetsCanBeFixedHeight = false;
-    if (!fromDocking)
-      widgetsCanBeFixedHeight = !m_regions.front()->checkWidgetsToBeFixedHeight(
-          fixedHeightWidgets, fromDocking);
+    // bool widgetsCanBeFixedHeight = false;
+    // if (!fromDocking)
+    //  widgetsCanBeFixedHeight =
+    //  !m_regions.front()->checkWidgetsToBeFixedHeight(
+    //      fixedHeightWidgets, fromDocking);
     if (!fromDocking && widgetsCanBeFixedWidth) {
       for (QWidget *widget : widgets) widget->setFixedWidth(widget->width());
     }
-    if (!fromDocking && widgetsCanBeFixedHeight) {
-      for (QWidget *widget : fixedHeightWidgets)
-        widget->setFixedHeight(widget->height());
-    }
+    // if (!fromDocking && widgetsCanBeFixedHeight) {
+    //  for (QWidget *widget : fixedHeightWidgets)
+    //    widget->setFixedHeight(widget->height());
+    //}
 
     m_regions.front()->calculateExtremalSizes();
 
@@ -549,12 +552,12 @@ void DockLayout::redistribute() {
         widget->setMinimumSize(0, 0);
       }
     }
-    if (!fromDocking && widgetsCanBeFixedHeight) {
-      for (QWidget *widget : fixedHeightWidgets) {
-        widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
-        widget->setMinimumSize(0, 0);
-      }
-    }
+    // if (!fromDocking && widgetsCanBeFixedHeight) {
+    //  for (QWidget *widget : fixedHeightWidgets) {
+    //    widget->setMaximumSize(QWIDGETSIZE_MAX, QWIDGETSIZE_MAX);
+    //    widget->setMinimumSize(0, 0);
+    //  }
+    //}
   }
 
   // Finally, apply Region geometries found

--- a/toonz/sources/toonzqt/docklayout.h
+++ b/toonz/sources/toonzqt/docklayout.h
@@ -535,8 +535,9 @@ public:
 
   bool checkWidgetsToBeFixedWidth(std::vector<QWidget *> &widgets,
                                   bool &fromDocking);
-  bool checkWidgetsToBeFixedHeight(std::vector<QWidget *> &widgets,
-                                   bool &fromDocking);
+  // This causes issues on maximize if the timeline is too tall.
+  // bool checkWidgetsToBeFixedHeight(std::vector<QWidget *> &widgets,
+  //                                 bool &fromDocking);
 
 private:
   // Setters - private


### PR DESCRIPTION
Closes #229 

Removes the code that sets a fixed height on the timeline at startup.  For some reason that was interfering with maximizing.