### PR TITLE
Do not remove unused styles 0 and 1 on default palettes

### DIFF
--- a/toonz/sources/toonzqt/styleselection.cpp
+++ b/toonz/sources/toonzqt/styleselection.cpp
@@ -703,6 +703,11 @@ void TStyleSelection::eraseUnusedStyle() {
   // Verifico quali stili sono usati e quali no
   std::map<int, bool> usedStyleIds;
   int pageCount = palette->getPageCount();
+  // We're on a default palette.  Never delete Style 0 and 1
+  if (palette->isDefaultPalette()) {
+    usedStyleIds[0] = true;
+    usedStyleIds[1] = true;
+  }
   for (auto const level : levels) {
     std::vector<TFrameId> fids;
     level->getFids(fids);
@@ -716,8 +721,9 @@ void TStyleSelection::eraseUnusedStyle() {
         for (j = 0; j < page->getStyleCount(); j++) {
           int styleId = page->getStyleId(j);
           if (m != 0 && usedStyleIds[styleId]) continue;
-          if (i == 0 && j == 0)  // Il primo stile della prima pagina non deve
-                                 // essere mai cancellato
+          if (i == 0 &&
+              (j == 0 || j == 1))  // Il primo stile della prima pagina non deve
+                                   // essere mai cancellato
           {
             usedStyleIds[styleId] = true;
             continue;


### PR DESCRIPTION
This PR fixes #231 

The `Delete Unused Styles` command assumed there was a level and marked off all styles used by the current level, excluding style id 0 only (normal behavior since day 1). For Default Palettes, there is no level so it didn't exclude style id 0 from the list and allowed it to be deleted.

Modified behavior such that 
- If it is a default palette, style id 0 and 1 are immediately excluded.
- Enhanced logic to also exclude style id 1 on normal level palettes in keeping with the inability to directly delete style id 1 normally.