### PR TITLE
More paste improvements

### DIFF
--- a/toonz/sources/common/tvrender/tpalette.cpp
+++ b/toonz/sources/common/tvrender/tpalette.cpp
@@ -278,7 +278,7 @@ TPalette::~TPalette() {
 
 TPalette *TPalette::clone() const {
   TPalette *palette = new TPalette;
-  palette->assign(this);
+  if (this && this->m_styles.size() > 0) palette->assign(this);
   return palette;
 }
 

--- a/toonz/sources/include/tools/rasterselection.h
+++ b/toonz/sources/include/tools/rasterselection.h
@@ -56,7 +56,7 @@ class DVAPI RasterSelection final : public TSelection {
   bool m_noAntialiasing;
 
 private:
-  void pasteSelection(const RasterImageData *data);
+  bool pasteSelection(const RasterImageData *data);
 
 public:
   RasterSelection();

--- a/toonz/sources/tnztools/rasterselection.cpp
+++ b/toonz/sources/tnztools/rasterselection.cpp
@@ -1024,6 +1024,19 @@ void RasterSelection::makeFloating() {
 
 void RasterSelection::pasteFloatingSelection() {
   if (!isFloating()) return;
+  if (!m_currentImageCell.getSimpleLevel()) {
+      const TXshCell& imageCell = TTool::getImageCell();
+
+      TImageP image =
+          imageCell.getImage(false, 1);  // => See the onImageChanged() warning !
+
+      TToonzImageP ti = (TToonzImageP)image;
+      TRasterImageP ri = (TRasterImageP)image;
+      if (!ti && !ri) return;
+
+      makeCurrent();
+      setCurrentImage(image, imageCell);
+  }
 
   assert(m_transformationCount != -1 && m_transformationCount != -2);
 
@@ -1201,6 +1214,19 @@ void RasterSelection::pasteSelection() {
   if (isFloating()) pasteFloatingSelection();
   selectNone();
   m_isPastedSelection = true;
+  if (!m_currentImageCell.getSimpleLevel()) {
+      const TXshCell& imageCell = TTool::getImageCell();
+
+      TImageP image =
+          imageCell.getImage(false, 1);  // => See the onImageChanged() warning !
+
+      TToonzImageP ti = (TToonzImageP)image;
+      TRasterImageP ri = (TRasterImageP)image;
+      if (!ti && !ri) return;
+
+      makeCurrent();
+      setCurrentImage(image, imageCell);
+  }
   if (m_currentImage->getPalette())
     m_oldPalette = m_currentImage->getPalette()->clone();
   if (!m_oldPalette)

--- a/toonz/sources/tnztools/strokeselection.cpp
+++ b/toonz/sources/tnztools/strokeselection.cpp
@@ -252,7 +252,10 @@ public:
     TTool::getApplication()->getCurrentTool()->getTool()->notifyImageChanged();
 
     clipboard->setMimeData(data, QClipboard::Clipboard);
-
+    TTool::getApplication()
+        ->getPaletteController()
+        ->getCurrentLevelPalette()
+        ->notifyPaletteChanged();
     TTool::getApplication()->getCurrentXsheet()->notifyXsheetChanged();
     notifyImageChanged();
   }

--- a/toonz/sources/toonz/filmstrip.cpp
+++ b/toonz/sources/toonz/filmstrip.cpp
@@ -1671,7 +1671,13 @@ void Filmstrip::updateCurrentLevelComboItem() {
   }
 
   for (int i = 0; i < m_levels.size(); i++) {
-    if (currentLevel->getName() == m_levels[i]->getName()) {
+    TXshSimpleLevel* tempLevel = m_levels[i];
+      std::wstring currName = currentLevel->getName();
+      int type = tempLevel->getType();
+      if (type < 0 || type > MESH_XSHLEVEL) break;
+      std::wstring tempName = tempLevel->getName();
+
+    if (!currentLevel->isEmpty() && !tempLevel->isEmpty() && currentLevel->getName() == tempLevel->getName()) {
       m_chooseLevelCombo->setCurrentIndex(i);
       return;
     }


### PR DESCRIPTION
Pasting an image with the selection tool enabled will now give the transformation box around the paste even without an active selection. 

This also takes care of a few paste crash issues.